### PR TITLE
Cleanup CC modes

### DIFF
--- a/lib/modules/libc/include/picotm/picotm-libc.h
+++ b/lib/modules/libc/include/picotm/picotm-libc.h
@@ -75,10 +75,12 @@ enum picotm_libc_file_type {
  * Concurrency-control mode for file-descriptor I/O.
  */
 enum picotm_libc_cc_mode {
-    PICOTM_LIBC_CC_MODE_NOUNDO = 0,  /**< \brief Set CC mode to irrevocablilty */
-    PICOTM_LIBC_CC_MODE_TS,          /**< \brief Set CC mode to optimistic timestamp checking */
-    PICOTM_LIBC_CC_MODE_2PL,         /**< \brief Set CC mode to pessimistic two-phase locking */
-    PICOTM_LIBC_CC_MODE_2PL_EXT      /**< \brief (Inofficial)Set CC mode to pessimistic two-phase locking with socket commit protocol */
+    /** Set CC mode to irrevocablilty */
+    PICOTM_LIBC_CC_MODE_NOUNDO = 0,
+    /** Set CC mode to optimistic timestamp checking */
+    PICOTM_LIBC_CC_MODE_TS,
+    /** Set CC mode to pessimistic two-phase locking */
+    PICOTM_LIBC_CC_MODE_2PL
 };
 
 /**

--- a/lib/modules/libc/include/picotm/picotm-libc.h
+++ b/lib/modules/libc/include/picotm/picotm-libc.h
@@ -77,8 +77,6 @@ enum picotm_libc_file_type {
 enum picotm_libc_cc_mode {
     /** Set CC mode to irrevocablilty */
     PICOTM_LIBC_CC_MODE_NOUNDO = 0,
-    /** Set CC mode to optimistic timestamp checking */
-    PICOTM_LIBC_CC_MODE_TS,
     /** Set CC mode to pessimistic two-phase locking */
     PICOTM_LIBC_CC_MODE_2PL
 };

--- a/lib/modules/libc/src/fd/fd_tx.c
+++ b/lib/modules/libc/src/fd/fd_tx.c
@@ -21,7 +21,7 @@ fd_tx_init(struct fd_tx* self)
     self->fildes = -1;
     self->ofd = -1;
 	self->flags = 0;
-	self->cc_mode = PICOTM_LIBC_CC_MODE_TS;
+	self->cc_mode = PICOTM_LIBC_CC_MODE_2PL;
 
     self->fcntltab = NULL;
     self->fcntltablen = 0;

--- a/lib/modules/libc/src/fd/fd_tx.c
+++ b/lib/modules/libc/src/fd/fd_tx.c
@@ -215,17 +215,7 @@ fd_tx_close_exec(struct fd_tx* self, int fildes, int* cookie, int noundo)
     };
 
     assert(self->cc_mode < sizeof(close_exec)/sizeof(close_exec[0]));
-
-    if (noundo) {
-        /* TX irrevokable */
-        self->cc_mode = PICOTM_LIBC_CC_MODE_NOUNDO;
-    } else {
-        /* TX revokable */
-        if ((self->cc_mode == PICOTM_LIBC_CC_MODE_NOUNDO)
-            || !close_exec[self->cc_mode]) {
-            return ERR_NOUNDO;
-        }
-    }
+    assert(close_exec[self->cc_mode]);
 
     return close_exec[self->cc_mode](self, fildes, cookie);
 }

--- a/lib/modules/libc/src/fd/fildes_tx.c
+++ b/lib/modules/libc/src/fd/fildes_tx.c
@@ -61,8 +61,6 @@ fildes_tx_init(struct fildes_tx* self, unsigned long module)
 {
     self->module = module;
 
-    self->optcc = false;
-
     self->ofd_tx_max_index = 0;
     self->fd_tx_max_fildes = 0;
 
@@ -102,18 +100,6 @@ fildes_tx_uninit(struct fildes_tx* self)
     openoptab_clear(&self->openoptab, &self->openoptablen);
 
     free(self->eventtab);
-}
-
-void
-fildes_tx_set_optcc(struct fildes_tx* self, int optcc)
-{
-    self->optcc = optcc;
-}
-
-int
-fildes_tx_get_optcc(const struct fildes_tx* self)
-{
-    return self->optcc;
 }
 
 void
@@ -282,8 +268,6 @@ fildes_tx_exec_accept(struct fildes_tx* self, int sockfd,
         return err;
     }
 
-    fildes_tx_set_optcc(self, false);
-
     /* Accept connection */
 
     int connfd = TEMP_FAILURE_RETRY(accept(sockfd, address, address_len));
@@ -366,8 +350,6 @@ fildes_tx_exec_bind(struct fildes_tx* self, int socket,
     if (err) {
         return err;
     }
-
-    fildes_tx_set_optcc(self, false);
 
     /* Bind */
 
@@ -557,8 +539,6 @@ fildes_tx_exec_connect(struct fildes_tx* self, int sockfd,
     if (err) {
         return err;
     }
-
-    fildes_tx_set_optcc(self, false);
 
     /* Connect */
 
@@ -762,8 +742,6 @@ fildes_tx_exec_fcntl(struct fildes_tx* self, int fildes, int cmd,
         return err;
     }
 
-    fildes_tx_set_optcc(self, false);
-
     /* Fcntl */
 
     res = ofd_tx_fcntl_exec(ofd_tx, fildes, cmd, arg, &cookie, isnoundo);
@@ -871,8 +849,6 @@ fildes_tx_exec_fsync(struct fildes_tx* self, int fildes, int isnoundo)
         return err;
     }
 
-    fildes_tx_set_optcc(self, false);
-
     /* Fsync */
 
     int cookie = -1;
@@ -976,8 +952,6 @@ fildes_tx_exec_listen(struct fildes_tx* self, int sockfd, int backlog,
         return err;
     }
 
-    fildes_tx_set_optcc(self, false);
-
     /* Connect */
 
     int cookie = -1;
@@ -1080,8 +1054,6 @@ fildes_tx_exec_lseek(struct fildes_tx* self, int fildes, off_t offset,
     if (err) {
         return err;
     }
-
-    fildes_tx_set_optcc(self, false);
 
     /* Seek */
 
@@ -1400,8 +1372,6 @@ fildes_tx_exec_pread(struct fildes_tx* self, int fildes, void* buf,
         return err;
     }
 
-    fildes_tx_set_optcc(self, false);
-
     /* pread */
 
     enum picotm_libc_validation_mode val_mode =
@@ -1510,8 +1480,6 @@ fildes_tx_exec_pwrite(struct fildes_tx* self, int fildes, const void* buf,
         return err;
     }
 
-    fildes_tx_set_optcc(self, false);
-
     /* Pwrite */
 
     int cookie = -1;
@@ -1616,8 +1584,6 @@ fildes_tx_exec_read(struct fildes_tx* self, int fildes, void* buf,
     if (err) {
         return err;
     }
-
-    fildes_tx_set_optcc(self, false);
 
     /* Read */
 
@@ -1725,8 +1691,6 @@ fildes_tx_exec_recv(struct fildes_tx* self, int sockfd, void* buffer,
     if (err) {
         return err;
     }
-
-    fildes_tx_set_optcc(self, false);
 
     /* Receive */
 
@@ -1912,8 +1876,6 @@ fildes_tx_exec_send(struct fildes_tx* self, int sockfd, const void* buffer,
         return err;
     }
 
-    fildes_tx_set_optcc(self, false);
-
     /* Send */
 
     int cookie = -1;
@@ -2018,8 +1980,6 @@ fildes_tx_exec_shutdown(struct fildes_tx* self, int sockfd, int how,
     if (err < 0) {
         return err;
     }
-
-    fildes_tx_set_optcc(self, false);
 
     /* Shutdown */
 
@@ -2230,8 +2190,6 @@ fildes_tx_exec_write(struct fildes_tx* self, int fildes, const void* buf,
     if (err) {
         return err;
     }
-
-    fildes_tx_set_optcc(self, false);
 
     /* Write */
 

--- a/lib/modules/libc/src/fd/fildes_tx.c
+++ b/lib/modules/libc/src/fd/fildes_tx.c
@@ -277,13 +277,12 @@ fildes_tx_exec_accept(struct fildes_tx* self, int sockfd,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0, &optcc);
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Accept connection */
 
@@ -363,13 +362,12 @@ fildes_tx_exec_bind(struct fildes_tx* self, int socket,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, socket, 0, &optcc);
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, socket, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Bind */
 
@@ -555,14 +553,12 @@ fildes_tx_exec_connect(struct fildes_tx* self, int sockfd,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Connect */
 
@@ -761,14 +757,12 @@ fildes_tx_exec_fcntl(struct fildes_tx* self, int fildes, int cmd,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Fcntl */
 
@@ -872,14 +866,12 @@ fildes_tx_exec_fsync(struct fildes_tx* self, int fildes, int isnoundo)
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Fsync */
 
@@ -979,14 +971,12 @@ fildes_tx_exec_listen(struct fildes_tx* self, int sockfd, int backlog,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0);
     if (err < 0) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Connect */
 
@@ -1086,14 +1076,12 @@ fildes_tx_exec_lseek(struct fildes_tx* self, int fildes, off_t offset,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Seek */
 
@@ -1407,14 +1395,12 @@ fildes_tx_exec_pread(struct fildes_tx* self, int fildes, void* buf,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* pread */
 
@@ -1429,15 +1415,6 @@ fildes_tx_exec_pread(struct fildes_tx* self, int fildes, void* buf,
 
     if (len < 0) {
         return len;
-    }
-
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    /* possibly validate optimistic domain */
-    if (ofd_tx_is_optimistic(ofd_tx)
-        && (val_mode == PICOTM_LIBC_VALIDATE_DOMAIN)
-        && ((err = ofd_tx_validate(ofd_tx, &error)) < 0)) {
-        return err;
     }
 
     /* inject event */
@@ -1528,14 +1505,12 @@ fildes_tx_exec_pwrite(struct fildes_tx* self, int fildes, const void* buf,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Pwrite */
 
@@ -1637,14 +1612,12 @@ fildes_tx_exec_read(struct fildes_tx* self, int fildes, void* buf,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Read */
 
@@ -1659,15 +1632,6 @@ fildes_tx_exec_read(struct fildes_tx* self, int fildes, void* buf,
 
     if (len < 0) {
         return len;
-    }
-
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    /* possibly validate optimistic domain */
-    if (ofd_tx_is_optimistic(ofd_tx)
-        && (val_mode == PICOTM_LIBC_VALIDATE_DOMAIN)
-        && ((err = ofd_tx_validate(ofd_tx, &error)) < 0)) {
-        return err;
     }
 
     /* Inject event */
@@ -1757,14 +1721,12 @@ fildes_tx_exec_recv(struct fildes_tx* self, int sockfd, void* buffer,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Receive */
 
@@ -1945,14 +1907,12 @@ fildes_tx_exec_send(struct fildes_tx* self, int sockfd, const void* buffer,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Send */
 
@@ -2054,14 +2014,12 @@ fildes_tx_exec_shutdown(struct fildes_tx* self, int sockfd, int how,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, sockfd, 0);
     if (err < 0) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Shutdown */
 
@@ -2268,14 +2226,12 @@ fildes_tx_exec_write(struct fildes_tx* self, int fildes, const void* buf,
     struct ofd_tx* ofd_tx = get_ofd_tx(self, fd_tx->ofd);
     assert(ofd_tx);
 
-    int optcc;
-    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0, &optcc);
-
+    err = ofd_tx_ref(ofd_tx, fd_tx->ofd, fildes, 0);
     if (err) {
         return err;
     }
 
-    fildes_tx_set_optcc(self, optcc);
+    fildes_tx_set_optcc(self, false);
 
     /* Write */
 

--- a/lib/modules/libc/src/fd/fildes_tx.h
+++ b/lib/modules/libc/src/fd/fildes_tx.h
@@ -24,8 +24,6 @@ struct openop;
 struct fildes_tx {
     unsigned long module;
 
-    bool optcc;
-
     struct ofd_tx ofd_tx[MAXNUMFD];
     struct fd_tx  fd_tx[MAXNUMFD];
 
@@ -54,12 +52,6 @@ fildes_tx_init(struct fildes_tx* self, unsigned long module);
 
 void
 fildes_tx_uninit(struct fildes_tx* self);
-
-void
-fildes_tx_set_optcc(struct fildes_tx* self, int optcc);
-
-int
-fildes_tx_get_optcc(const struct fildes_tx* self);
 
 void
 fildes_tx_set_validation_mode(struct fildes_tx* self,

--- a/lib/modules/libc/src/fd/module.c
+++ b/lib/modules/libc/src/fd/module.c
@@ -506,13 +506,6 @@ fd_module_pread(int fildes, void* buf, size_t nbyte, off_t off)
         res = fildes_tx_exec_pread(fildes_tx, fildes, buf, nbyte, off,
                                 picotm_is_irrevocable());
 
-        /* possibly validate all optimistic domains */
-        if ((fildes_tx_get_validation_mode(fildes_tx) == PICOTM_LIBC_VALIDATE_FULL)
-            && fildes_tx_get_optcc(fildes_tx)
-            && !picotm_is_valid()) {
-            res = ERR_CONFLICT;
-        }
-
         switch (res) {
             case ERR_CONFLICT:
                 picotm_restart();
@@ -564,13 +557,6 @@ fd_module_read(int fildes, void* buf, size_t nbyte)
     do {
         res = fildes_tx_exec_read(fildes_tx, fildes, buf, nbyte,
                                picotm_is_irrevocable());
-
-        /* possibly validate all optimistic domains */
-        if ((fildes_tx_get_validation_mode(fildes_tx) == PICOTM_LIBC_VALIDATE_FULL)
-            && fildes_tx_get_optcc(fildes_tx)
-            && !picotm_is_valid()) {
-            res = ERR_CONFLICT;
-        }
 
         switch (res) {
             case ERR_CONFLICT:

--- a/lib/modules/libc/src/fd/ofd.h
+++ b/lib/modules/libc/src/fd/ofd.h
@@ -5,7 +5,6 @@
 #ifndef OFD_H
 #define OFD_H
 
-#include "cmap.h"
 #include "counter.h"
 #include "ofdid.h"
 #include "picotm/picotm-libc.h"
@@ -24,9 +23,7 @@
 #define OFD_FL_WANTNEW  (1<<2)
 #define OFD_FL_LAST_BIT (2)
 
-struct cmapss;
 struct picotm_error;
-struct rwlocktab;
 struct rwstatemap;
 
 struct ofd
@@ -40,18 +37,13 @@ struct ofd
     enum picotm_libc_file_type type;
 
     enum picotm_libc_cc_mode cc_mode;
-    struct counter ver; /**< \brief Version, incremented on commit, optimistic CC */
     struct rwlock  rwlock; /**< \brief Lock, pessimistic CC */
 
     struct {
         struct {
             /** \brief global file position */
             off_t                offset;
-            /** \brief Version table, optimistic CC */
-            struct cmap          cmap;
-/*            struct counter_table vertab;*/
             /** \brief Lock table, pessimistic CC */
-            /*struct rwlocktab     rwlocktab;*/
             struct rwlockmap     rwlockmap;
         } regular;
     } data;
@@ -110,42 +102,6 @@ ofd_wrlock(struct ofd *ofd);
 
 void
 ofd_unlock(struct ofd *ofd);
-
-/*
- * Optimistic CC
- */
-
-/** \brief Returns the version of the open file description. */
-count_type
-ofd_ts_get_state_version(struct ofd *ofd);
-
-/** \brief Returns the region versions of the underliing file buffer. */
-int
-ofd_ts_get_region_versions(struct ofd *ofd, size_t nbyte, off_t offset, struct cmapss *cmapss);
-
-/** \brief Validates the open file descriptor's version. */
-int
-ofd_ts_validate_state(struct ofd *ofd, count_type ver,
-                      struct picotm_error* error);
-
-/** \brief Validates the region versions of the underlying file buffer. */
-int
-ofd_ts_validate_region(struct ofd *ofd, size_t nbyte, off_t off, struct cmapss *cmapss);
-
-/** \brief Increments the state's version of the underlying file buffer. */
-long long
-ofd_ts_inc_state_version(struct ofd *ofd);
-
-/** \brief Increments the regions' versions of the underlying file buffer. */
-int
-ofd_ts_inc_region_versions(struct ofd *ofd, size_t nbyte, off_t off,
-                           struct cmapss *cmapss, struct picotm_error* error);
-
-int
-ofd_ts_lock_region(struct ofd *ofd, size_t nbyte, off_t offset, struct cmapss *cmapss);
-
-int
-ofd_ts_unlock_region(struct ofd *ofd, size_t nbyte, off_t offset, struct cmapss *cmapss);
 
 /*
  * Pessimistic CC

--- a/lib/modules/libc/src/fd/ofd_tx.c
+++ b/lib/modules/libc/src/fd/ofd_tx.c
@@ -247,8 +247,7 @@ ofd_tx_clear_cc(struct ofd_tx* self, struct picotm_error* error)
  */
 
 enum error_code
-ofd_tx_ref(struct ofd_tx* self, int ofdindex, int fildes, unsigned long flags,
-           int* optcc)
+ofd_tx_ref(struct ofd_tx* self, int ofdindex, int fildes, unsigned long flags)
 {
     assert(self);
     assert(ofdindex >= 0);
@@ -287,11 +286,6 @@ ofd_tx_ref(struct ofd_tx* self, int ofdindex, int fildes, unsigned long flags,
 
         self->modedata.tpl.rwstate = RW_NOLOCK;
         self->modedata.tpl.locktablen = 0;
-    }
-
-    if (optcc) {
-        /* Signal optimistic CC */
-        *optcc = (self->cc_mode == PICOTM_LIBC_CC_MODE_TS);
     }
 
     return 0;

--- a/lib/modules/libc/src/fd/ofd_tx.h
+++ b/lib/modules/libc/src/fd/ofd_tx.h
@@ -6,7 +6,6 @@
 
 #include <sys/socket.h>
 #include <sys/types.h>
-#include "cmapss.h"
 #include "counter.h"
 #include "fcntlop.h"
 #include "picotm/picotm-libc.h"
@@ -76,15 +75,6 @@ struct ofd_tx
     off_t size;
 
     struct {
-        struct {
-            /** Last ofd version, modified by ofd_tx */
-            count_type     ver;
-            struct cmapss  cmapss;
-            /** Table of all regions to be locked */
-            struct region* locktab;
-            size_t         locktablen;
-            size_t         locktabsiz;
-        } ts;
         struct {
             /** State of the local ofd lock */
             enum   rwstate    rwstate;
@@ -166,28 +156,6 @@ ofd_tx_pre_commit(struct ofd_tx* self);
  */
 int
 ofd_tx_post_commit(struct ofd_tx* self);
-
-/**
- * Returns true if optimistic CC is in use, false otherwise.
- */
-int
-ofd_tx_is_optimistic(const struct ofd_tx* self);
-
-/*
- * optimistic CC
- */
-
-int
-ofd_tx_ts_get_state_version(struct ofd_tx* self);
-
-int
-ofd_tx_ts_get_region_versions(struct ofd_tx* self, size_t nbyte, off_t offset);
-
-int
-ofd_tx_ts_validate_state(struct ofd_tx* self);
-
-int
-ofd_tx_ts_validate_region(struct ofd_tx* self, size_t nbyte, off_t offset);
 
 /*
  * pessimistic CC

--- a/lib/modules/libc/src/fd/ofd_tx.h
+++ b/lib/modules/libc/src/fd/ofd_tx.h
@@ -122,8 +122,7 @@ ofd_tx_clear_cc(struct ofd_tx* self, struct picotm_error* error);
  * Acquire a reference on the open file description
  */
 enum error_code
-ofd_tx_ref(struct ofd_tx* self, int ofd, int fildes, unsigned long flags,
-           int* optcc);
+ofd_tx_ref(struct ofd_tx* self, int ofd, int fildes, unsigned long flags);
 
 /**
  * Release reference

--- a/lib/modules/libc/src/libc.c
+++ b/lib/modules/libc/src/libc.c
@@ -36,9 +36,7 @@ picotm_libc_get_error_recovery()
 
 static enum picotm_libc_cc_mode g_file_type_cc_mode[] = {
     PICOTM_LIBC_CC_MODE_NOUNDO,
-    PICOTM_LIBC_CC_MODE_2PL,
-    PICOTM_LIBC_CC_MODE_TS,
-    PICOTM_LIBC_CC_MODE_TS
+    PICOTM_LIBC_CC_MODE_2PL
 };
 
 static enum picotm_libc_validation_mode g_validation_mode;

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -183,7 +183,7 @@ opt_off(const char *optarg)
 static int
 opt_regular_ccmode(const char *optarg)
 {
-    static const char * const optstr[] = { "noundo", "ts", "2pl", "2pl-ext" };
+    static const char * const optstr[] = { "noundo", "2pl"};
     size_t i;
 
     for (i = 0; i < sizeof(optstr)/sizeof(optstr[0]); ++i) {


### PR DESCRIPTION
This patch set removed the CC modes named TS and 2PL_EXT. Both are untested, unused, and/or slow.