### PR TITLE
lib: Support disabling assertions during package configuration

### DIFF
--- a/lib/configure.ac
+++ b/lib/configure.ac
@@ -57,6 +57,8 @@ dnl
 dnl System headers and libraries
 dnl
 
+AC_HEADER_ASSERT
+
 AC_CHECK_HEADERS([sys/cdefs.h])
 
 


### PR DESCRIPTION
Assertions can now be disabled by passing `--disable-assert` to the
configure script.