### PR TITLE
libc: Fix file-buffer record offsets

### DIFF
--- a/lib/modules/libc/src/fd/ofd.c
+++ b/lib/modules/libc/src/fd/ofd.c
@@ -109,7 +109,7 @@ ofd_init(struct ofd* ofd, struct picotm_error* error)
 
     ofd->data.regular.offset = 0;
 
-    rwlockmap_init(&ofd->data.regular.rwlockmap, RECBITS, error);
+    rwlockmap_init(&ofd->data.regular.rwlockmap, error);
     if (picotm_error_is_set(error)) {
         goto err_rwlockmap_init;
     }

--- a/lib/modules/libc/src/fd/rwlockmap.h
+++ b/lib/modules/libc/src/fd/rwlockmap.h
@@ -50,8 +50,7 @@ struct rwlockmap
 };
 
 void
-rwlockmap_init(struct rwlockmap* rwlockmap, unsigned long record_bits,
-               struct picotm_error* error);
+rwlockmap_init(struct rwlockmap* rwlockmap, struct picotm_error* error);
 
 void
 rwlockmap_uninit(struct rwlockmap *rwlockmap);

--- a/lib/modules/libc/src/fd/rwstatemap.c
+++ b/lib/modules/libc/src/fd/rwstatemap.c
@@ -150,6 +150,12 @@ rwstatemap_create_page_fn(unsigned long long offset,
     return (uintptr_t)statepg;
 }
 
+static unsigned long long
+key_bits(unsigned long long offset, unsigned long page_nbits)
+{
+    return offset >> page_nbits;
+}
+
 bool
 rwstatemap_rdlock(struct rwstatemap* rwstatemap,
                   unsigned long long length, unsigned long long offset,
@@ -167,7 +173,7 @@ rwstatemap_rdlock(struct rwstatemap* rwstatemap,
     while (length) {
 
         uintptr_t value = picotm_treemap_find_value(&rwstatemap->super,
-                                                    offset,
+                                                    key_bits(offset, RWLOCKMAP_PAGE_NBITS),
                                                     rwstatemap_create_page_fn,
                                                     error);
         if (picotm_error_is_set(error)) {
@@ -245,7 +251,7 @@ rwstatemap_wrlock(struct rwstatemap* rwstatemap,
     while (length) {
 
         uintptr_t value = picotm_treemap_find_value(&rwstatemap->super,
-                                                    offset,
+                                                    key_bits(offset, RWLOCKMAP_PAGE_NBITS),
                                                     rwstatemap_create_page_fn,
                                                     error);
         if (picotm_error_is_set(error)) {
@@ -318,7 +324,7 @@ rwstatemap_unlock(struct rwstatemap *rwstatemap, unsigned long long length,
     while (length) {
 
         uintptr_t value = picotm_treemap_find_value(&rwstatemap->super,
-                                                    offset,
+                                                    key_bits(offset, RWLOCKMAP_PAGE_NBITS),
                                                     rwstatemap_create_page_fn,
                                                     error);
         if (picotm_error_is_set(error)) {


### PR DESCRIPTION
The patch set for converting the file-descriptor I/O module to picotm's
treemap structures introduced a bug where file offsets where associated
with the wrong file-buffer records. This patch fixes the problem.