### PR TITLE
libc: Add directory support

### DIFF
--- a/lib/modules/libc/include/picotm/picotm-libc.h
+++ b/lib/modules/libc/include/picotm/picotm-libc.h
@@ -83,6 +83,7 @@ enum picotm_libc_file_type {
     PICOTM_LIBC_FILE_TYPE_CHRDEV = 0,   /**< \brief Character device */
     PICOTM_LIBC_FILE_TYPE_FIFO,         /**< \brief FIFO */
     PICOTM_LIBC_FILE_TYPE_REGULAR,      /**< \brief Regular file */
+    PICOTM_LIBC_FILE_TYPE_DIR,          /**< \brief Directory */
     PICOTM_LIBC_FILE_TYPE_SOCKET        /**< \brief Socket */
 };
 

--- a/lib/modules/libc/src/Makefile.am
+++ b/lib/modules/libc/src/Makefile.am
@@ -35,6 +35,12 @@ libpicotm_c_la_SOURCES = allocator/allocator_tx.c \
                          fd/chrdevtab.h \
                          fd/chrdev_tx.c \
                          fd/chrdev_tx.h \
+                         fd/dir.c \
+                         fd/dir.h \
+                         fd/dirtab.c \
+                         fd/dirtab.h \
+                         fd/dir_tx.c \
+                         fd/dir_tx.h \
                          fd/fcntlop.c \
                          fd/fcntlop.h \
                          fd/fcntloptab.c \

--- a/lib/modules/libc/src/fd/dir.c
+++ b/lib/modules/libc/src/fd/dir.c
@@ -1,0 +1,248 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "dir.h"
+#include <assert.h>
+#include <picotm/picotm-error.h>
+#include <picotm/picotm-lib-rwstate.h>
+#include <stdlib.h>
+
+void
+dir_init(struct dir* self, struct picotm_error* error)
+{
+    assert(self);
+
+    int err = pthread_rwlock_init(&self->lock, NULL);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+
+    picotm_ref_init(&self->ref, 0);
+    ofdid_clear(&self->id);
+
+    self->cc_mode = PICOTM_LIBC_CC_MODE_NOUNDO;
+    picotm_rwlock_init(&self->rwlock);
+}
+
+void
+dir_uninit(struct dir* self)
+{
+    picotm_rwlock_uninit(&self->rwlock);
+
+    pthread_rwlock_destroy(&self->lock);
+}
+
+static void
+dir_rdlock(struct dir* self)
+{
+    assert(self);
+
+    int err = pthread_rwlock_rdlock(&self->lock);
+    if (err) {
+        abort();
+    }
+}
+
+static void
+dir_wrlock(struct dir* self)
+{
+    assert(self);
+
+    int err = pthread_rwlock_wrlock(&self->lock);
+    if (err) {
+        abort();
+    }
+}
+
+static void
+dir_unlock(struct dir* self)
+{
+    assert(self);
+
+    int err = pthread_rwlock_unlock(&self->lock);
+    if (err) {
+        abort();
+    }
+}
+
+enum picotm_libc_cc_mode
+dir_get_cc_mode(struct dir* self)
+{
+    assert(self);
+
+    dir_rdlock(self);
+    enum picotm_libc_cc_mode cc_mode = self->cc_mode;
+    dir_unlock(self);
+
+    return cc_mode;
+}
+
+/*
+ * Referencing
+ */
+
+/* requires internal writer lock */
+static void
+ref_or_set_up(struct dir* self, int fildes, struct picotm_error* error)
+{
+    assert(self);
+
+    bool first_ref = picotm_ref_up(&self->ref);
+    if (!first_ref) {
+        /* we got a set-up instance; signal success */
+        return;
+    }
+
+    ofdid_init_from_fildes(&self->id, fildes, error);
+    if (picotm_error_is_set(error)) {
+        goto err_ofdid_init_from_fildes;
+    }
+
+    self->cc_mode =
+        picotm_libc_get_file_type_cc_mode(PICOTM_LIBC_FILE_TYPE_DIR);
+
+    return;
+
+err_ofdid_init_from_fildes:
+    dir_unref(self);
+}
+
+void
+dir_ref_or_set_up(struct dir* self, int fildes,
+                     struct picotm_error* error)
+{
+    dir_wrlock(self);
+
+    ref_or_set_up(self, fildes, error);
+    if (picotm_error_is_set(error)) {
+        goto err_ref_or_set_up;
+    }
+
+    dir_unlock(self);
+
+    return;
+
+err_ref_or_set_up:
+    dir_unlock(self);
+}
+
+void
+dir_ref(struct dir* self)
+{
+    picotm_ref_up(&self->ref);
+}
+
+void
+dir_unref(struct dir* self)
+{
+    assert(self);
+
+    dir_wrlock(self);
+
+    bool final_ref = picotm_ref_down(&self->ref);
+    if (!final_ref) {
+        goto unlock;
+    }
+
+    /* We clear the id on releasing the final reference. This
+     * instance remains initialized, but is available for later
+     * use. */
+    ofdid_clear(&self->id);
+
+unlock:
+    dir_unlock(self);
+}
+
+int
+dir_cmp_and_ref_or_set_up(struct dir* self, const struct ofdid* id,
+                          int fildes, struct picotm_error* error)
+{
+    assert(self);
+
+    dir_wrlock(self);
+
+    int cmp = ofdidcmp(&self->id, id);
+    if (cmp) {
+        goto unlock; /* ids are not equal; only return */
+    }
+
+    ref_or_set_up(self, fildes, error);
+    if (picotm_error_is_set(error)) {
+        goto err_ref_or_set_up;
+    }
+
+unlock:
+    dir_unlock(self);
+
+    return cmp;
+
+err_ref_or_set_up:
+    dir_unlock(self);
+    return cmp;
+}
+
+int
+dir_cmp_and_ref(struct dir* self, const struct ofdid* id)
+{
+    assert(self);
+
+    dir_rdlock(self);
+
+    int cmp = ofdidcmp(&self->id, id);
+    if (!cmp) {
+        dir_ref(self);
+    }
+
+    dir_unlock(self);
+
+    return cmp;
+}
+
+void
+dir_try_rdlock_state(struct dir* self, struct picotm_rwstate* rwstate,
+                        struct picotm_error* error)
+{
+    assert(self);
+
+    picotm_rwstate_try_rdlock(rwstate, &self->rwlock, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+}
+
+void
+dir_try_wrlock_state(struct dir* self, struct picotm_rwstate* rwstate,
+                        struct picotm_error* error)
+{
+    assert(self);
+
+    picotm_rwstate_try_wrlock(rwstate, &self->rwlock, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+}
+
+void
+dir_unlock_state(struct dir* self, struct picotm_rwstate* rwstate)
+{
+    assert(self);
+
+    picotm_rwstate_unlock(rwstate, &self->rwlock);
+}

--- a/lib/modules/libc/src/fd/dir.h
+++ b/lib/modules/libc/src/fd/dir.h
@@ -1,0 +1,162 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <picotm/picotm-lib-ref.h>
+#include <picotm/picotm-lib-rwlock.h>
+#include <pthread.h>
+#include "ofdid.h"
+#include "picotm/picotm-libc.h"
+
+/**
+ * \cond impl || libc_impl || libc_impl_fd
+ * \ingroup libc_impl
+ * \ingroup libc_impl_fd
+ * \file
+ * \endcond
+ */
+
+#define DIR_FL_WANTNEW  (1<<2)
+#define DIR_FL_LAST_BIT (2)
+
+struct picotm_rwstate;
+
+/**
+ * Represents a directory's open file description.
+ */
+struct dir {
+
+    /** Internal lock. */
+    pthread_rwlock_t lock;
+
+    /** The reference counter. */
+    struct picotm_shared_ref16 ref;
+
+    /** The directory's unique id. */
+    struct ofdid id;
+
+    /** Concurrency-control mode for the directory. */
+    enum picotm_libc_cc_mode cc_mode;
+
+    /** Reader/writer state lock. */
+    struct picotm_rwlock rwlock;
+};
+
+/**
+ * \brief Initializes a dir instance.
+ * \param       self    The dir instance to initialize.
+ * \param[out]  error   Returns an error to the caller.
+ */
+void
+dir_init(struct dir* self, struct picotm_error* error);
+
+/**
+ * \brief Uninitializes a dir structure.
+ * \param   self    The dir instance to uninitialize.
+ */
+void
+dir_uninit(struct dir* self);
+
+/**
+ * \brief Sets up an instance of `struct dir` or acquires a reference
+ *        on an already set-up instance.
+ * \param       self    The dir instance.
+ * \param       fildes  The directory's file descriptor.
+ * \param[out]  error   Returns an error to the caller.
+ */
+void
+dir_ref_or_set_up(struct dir* self, int fildes, struct picotm_error* error);
+
+/**
+ * \brief Acquires a reference on an instance of `struct dir`.
+ * \param   self    The dir instance.
+ */
+void
+dir_ref(struct dir* self);
+
+/**
+ * \brief Compares the dir's id to an id and acquires a reference if both
+ *        id's are equal.
+ * \param   self    The dir instance.
+ * \param   id      The id to compare to.
+ * \returns A value less than, equal to, or greater than if the dir's id
+ *          is less than, equal to, or greater than the given id.
+ */
+int
+dir_cmp_and_ref(struct dir* self, const struct ofdid* id);
+
+/**
+ * \brief Compares the dir's id to an id and acquires a reference if both
+ *        id's are equal. The dir instance is set up from the provided
+ *        file descriptor if necessary.
+ * \param       self        The dir instance.
+ * \param       id          The id to compare to.
+ * \param       fildes      The directory's file descriptor.
+ * \param[out]  error       Returns an error ot the caller.
+ * \returns A value less than, equal to, or greater than if the ofd's id is
+ *          less than, equal to, or greater than the given id.
+ */
+int
+dir_cmp_and_ref_or_set_up(struct dir* self, const struct ofdid* id,
+                          int fildes, struct picotm_error* error);
+
+/**
+ * \brief Unreferences a directory.
+ * \param   self    The dir instance.
+ */
+void
+dir_unref(struct dir* self);
+
+/**
+ * \brief Returns the current concurrency-control mode of a dir
+ *        instance.
+ * \param   self    The dir instance.
+ * \returns The current concurrency-control mode of the given dir.
+ */
+enum picotm_libc_cc_mode
+dir_get_cc_mode(struct dir* self);
+
+/**
+ * \brief Tries to acquire a reader lock on a directory.
+ * \param       self        The dir instance.
+ * \param       rwstate     The transaction's reader/writer state.
+ * \param[out]  error       Returns an error ot the caller.
+ */
+void
+dir_try_rdlock_state(struct dir* self, struct picotm_rwstate* rwstate,
+                     struct picotm_error* error);
+
+/**
+ * \brief Tries to acquire a writer lock on a directory.
+ * \param       self        The dir instance.
+ * \param       rwstate     The transaction's reader/writer state.
+ * \param[out]  error       Returns an error ot the caller.
+ */
+void
+dir_try_wrlock_state(struct dir* self, struct picotm_rwstate* rwstate,
+                     struct picotm_error* error);
+
+/**
+ * \brief Releases a lock on a directory.
+ * \param   self    The dir instance.
+ * \param   rwstate The transaction's reader/writer state.
+ */
+void
+dir_unlock_state(struct dir* self, struct picotm_rwstate* rwstate);

--- a/lib/modules/libc/src/fd/dir_tx.c
+++ b/lib/modules/libc/src/fd/dir_tx.c
@@ -1,0 +1,485 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "dir_tx.h"
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <picotm/picotm-error.h>
+#include <picotm/picotm-lib-ptr.h>
+#include <picotm/picotm-lib-tab.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "dir.h"
+#include "fcntlop.h"
+#include "fcntloptab.h"
+
+struct dir_tx*
+dir_tx_of_ofd_tx(struct ofd_tx* ofd_tx)
+{
+    assert(ofd_tx);
+    assert(ofd_tx_file_type(ofd_tx) == PICOTM_LIBC_FILE_TYPE_DIR);
+
+    return picotm_containerof(ofd_tx, struct dir_tx, base);
+}
+
+static void
+ref_ofd_tx(struct ofd_tx* ofd_tx)
+{
+    dir_tx_ref(dir_tx_of_ofd_tx(ofd_tx));
+}
+
+static void
+unref_ofd_tx(struct ofd_tx* ofd_tx)
+{
+    dir_tx_unref(dir_tx_of_ofd_tx(ofd_tx));
+}
+
+void
+dir_tx_init(struct dir_tx* self)
+{
+    assert(self);
+
+    picotm_ref_init(&self->ref, 0);
+
+    memset(&self->active_list, 0, sizeof(self->active_list));
+
+    ofd_tx_init(&self->base, PICOTM_LIBC_FILE_TYPE_DIR,
+                ref_ofd_tx, unref_ofd_tx);
+
+    self->dir = NULL;
+
+    self->flags = 0;
+
+    self->fcntltab = NULL;
+    self->fcntltablen = 0;
+
+    self->cc_mode = PICOTM_LIBC_CC_MODE_NOUNDO;
+
+    picotm_rwstate_init(&self->rwstate);
+}
+
+void
+dir_tx_uninit(struct dir_tx* self)
+{
+    assert(self);
+
+    fcntloptab_clear(&self->fcntltab, &self->fcntltablen);
+}
+
+/*
+ * Validation
+ */
+
+void
+dir_tx_lock(struct dir_tx* self)
+{
+    assert(self);
+}
+
+void
+dir_tx_unlock(struct dir_tx* self)
+{
+    assert(self);
+}
+
+static void
+validate_noundo(struct dir_tx* self, struct picotm_error* error)
+{ }
+
+static void
+validate_2pl(struct dir_tx* self, struct picotm_error* error)
+{
+    assert(self);
+}
+
+void
+dir_tx_validate(struct dir_tx* self, struct picotm_error* error)
+{
+    static void (* const validate[])(struct dir_tx*, struct picotm_error*) = {
+        validate_noundo,
+        validate_2pl
+    };
+
+    if (!dir_tx_holds_ref(self)) {
+        return;
+    }
+
+    validate[self->cc_mode](self, error);
+}
+
+/*
+ * Update CC
+ */
+
+static void
+update_cc_noundo(struct dir_tx* self, struct picotm_error* error)
+{ }
+
+static void
+update_cc_2pl(struct dir_tx* self, struct picotm_error* error)
+{
+    assert(self);
+    assert(self->cc_mode == PICOTM_LIBC_CC_MODE_2PL);
+
+    /* release lock on directory */
+    dir_unlock_state(self->dir, &self->rwstate);
+}
+
+void
+dir_tx_update_cc(struct dir_tx* self, struct picotm_error* error)
+{
+    static void (* const update_cc[])(struct dir_tx*, struct picotm_error*) = {
+        update_cc_noundo,
+        update_cc_2pl
+    };
+
+    assert(dir_tx_holds_ref(self));
+
+    update_cc[self->cc_mode](self, error);
+}
+
+/*
+ * Clear CC
+ */
+
+static void
+clear_cc_noundo(struct dir_tx* self, struct picotm_error* error)
+{
+    assert(self);
+    assert(self->cc_mode == PICOTM_LIBC_CC_MODE_NOUNDO);
+}
+
+static void
+clear_cc_2pl(struct dir_tx* self, struct picotm_error* error)
+{
+    assert(self);
+    assert(self->cc_mode == PICOTM_LIBC_CC_MODE_2PL);
+
+    /* release lock on directory */
+    dir_unlock_state(self->dir, &self->rwstate);
+}
+
+void
+dir_tx_clear_cc(struct dir_tx* self, struct picotm_error* error)
+{
+    static void (* const clear_cc[])(struct dir_tx*, struct picotm_error*) = {
+        clear_cc_noundo,
+        clear_cc_2pl
+    };
+
+    assert(dir_tx_holds_ref(self));
+
+    clear_cc[self->cc_mode](self, error);
+}
+
+/*
+ * Referencing
+ */
+
+void
+dir_tx_ref_or_set_up(struct dir_tx* self, struct dir* dir,
+                        int fildes, unsigned long flags,
+                        struct picotm_error* error)
+{
+    assert(self);
+    assert(dir);
+
+    bool first_ref = picotm_ref_up(&self->ref);
+    if (!first_ref) {
+        return;
+    }
+
+    /* acquire reference on directory */
+    dir_ref(dir);
+
+    /* setup fields */
+
+    self->dir = dir;
+    self->cc_mode = dir_get_cc_mode(dir);
+    self->flags = 0;
+
+    self->fcntltablen = 0;
+
+    picotm_rwstate_set_status(&self->rwstate, PICOTM_RWSTATE_UNLOCKED);
+}
+
+void
+dir_tx_ref(struct dir_tx* self)
+{
+    picotm_ref_up(&self->ref);
+}
+
+void
+dir_tx_unref(struct dir_tx* self)
+{
+    assert(self);
+
+    bool final_ref = picotm_ref_down(&self->ref);
+    if (!final_ref) {
+        return;
+    }
+
+    dir_unref(self->dir);
+    self->dir = NULL;
+}
+
+bool
+dir_tx_holds_ref(struct dir_tx* self)
+{
+    assert(self);
+
+    return picotm_ref_count(&self->ref) > 0;
+}
+
+/*
+ * fcntl()
+ */
+
+static int
+fcntl_exec_noundo(struct dir_tx* self, int fildes, int cmd,
+                  union fcntl_arg* arg, int* cookie,
+                  struct picotm_error* error)
+{
+    int res = 0;
+
+    assert(arg);
+
+    switch (cmd) {
+        case F_GETFD:
+        case F_GETFL:
+        case F_GETOWN:
+            res = TEMP_FAILURE_RETRY(fcntl(fildes, cmd));
+            arg->arg0 = res;
+            break;
+        case F_GETLK:
+            res = TEMP_FAILURE_RETRY(fcntl(fildes, cmd, arg->arg1));
+            break;
+        case F_SETFL:
+        case F_SETFD:
+        case F_SETOWN:
+            res = TEMP_FAILURE_RETRY(fcntl(fildes, cmd, arg->arg0));
+            break;
+        case F_SETLK:
+        case F_SETLKW:
+            res = TEMP_FAILURE_RETRY(fcntl(fildes, cmd, arg->arg1));
+            break;
+        default:
+            errno = EINVAL;
+            res = -1;
+            break;
+    }
+
+    if (res < 0) {
+        picotm_error_set_errno(error, errno);
+        return res;
+    }
+
+    return res;
+}
+
+static int
+fcntl_exec_2pl(struct dir_tx* self, int fildes, int cmd,
+               union fcntl_arg* arg, int* cookie, struct picotm_error* error)
+{
+    assert(arg);
+
+    switch (cmd) {
+        case F_GETFD:
+        case F_GETFL:
+        case F_GETOWN: {
+
+            /* Read-lock directory */
+            dir_try_rdlock_state(self->dir, &self->rwstate, error);
+            if (picotm_error_is_set(error)) {
+                return -1;
+            }
+
+            int res = TEMP_FAILURE_RETRY(fcntl(fildes, cmd));
+            arg->arg0 = res;
+            if (res < 0) {
+                picotm_error_set_errno(error, errno);
+                return res;
+            }
+            return res;
+        }
+        case F_GETLK: {
+
+            /* Read-lock directory */
+            dir_try_rdlock_state(self->dir, &self->rwstate, error);
+            if (picotm_error_is_set(error)) {
+                return -1;
+            }
+
+            int res = TEMP_FAILURE_RETRY(fcntl(fildes, cmd, arg->arg1));
+            if (res < 0) {
+                picotm_error_set_errno(error, errno);
+                return res;
+            }
+            return res;
+        }
+        case F_SETFL:
+        case F_SETFD:
+        case F_SETOWN:
+        case F_SETLK:
+        case F_SETLKW:
+            picotm_error_set_revocable(error);
+            return -1;
+        default:
+            break;
+    }
+
+    picotm_error_set_errno(error, EINVAL);
+    return -1;
+}
+
+int
+dir_tx_fcntl_exec(struct dir_tx* self, int fildes, int cmd,
+                  union fcntl_arg* arg, bool isnoundo, int* cookie,
+                  struct picotm_error* error)
+{
+    static int (* const fcntl_exec[2])(struct dir_tx*,
+                                       int,
+                                       int,
+                                       union fcntl_arg*,
+                                       int*,
+                                       struct picotm_error*) = {
+        fcntl_exec_noundo,
+        fcntl_exec_2pl
+    };
+
+    if (isnoundo) {
+        /* TX irrevokable */
+        self->cc_mode = PICOTM_LIBC_CC_MODE_NOUNDO;
+    } else {
+        /* TX revokable */
+        if ((self->cc_mode == PICOTM_LIBC_CC_MODE_NOUNDO)
+            || !fcntl_exec[self->cc_mode]) {
+            picotm_error_set_revocable(error);
+            return -1;
+        }
+    }
+
+    return fcntl_exec[self->cc_mode](self, fildes, cmd, arg, cookie, error);
+}
+
+void
+dir_tx_fcntl_apply(struct dir_tx* self, int fildes, int cookie,
+                   struct picotm_error* error)
+{ }
+
+void
+dir_tx_fcntl_undo(struct dir_tx* self, int fildes, int cookie,
+                  struct picotm_error* error)
+{ }
+
+/*
+ * fsync()
+ */
+
+static int
+fsync_exec_noundo(int fildes, int* cookie, struct picotm_error* error)
+{
+    int res = fsync(fildes);
+    if (res < 0) {
+        picotm_error_set_errno(error, errno);
+        return res;
+    }
+    return res;
+}
+
+static int
+fsync_exec_2pl(int fildes, int* cookie, struct picotm_error* error)
+{
+    /* Signal apply/undo */
+    *cookie = 0;
+
+    return 0;
+}
+
+int
+dir_tx_fsync_exec(struct dir_tx* self, int fildes, bool isnoundo, int* cookie,
+                  struct picotm_error* error)
+{
+    static int (* const fsync_exec[2])(int, int*, struct picotm_error*) = {
+        fsync_exec_noundo,
+        fsync_exec_2pl
+    };
+
+    if (isnoundo) {
+        /* TX irrevokable */
+        self->cc_mode = PICOTM_LIBC_CC_MODE_NOUNDO;
+    } else {
+        /* TX revokable */
+        if ((self->cc_mode == PICOTM_LIBC_CC_MODE_NOUNDO)
+            || !fsync_exec[self->cc_mode]) {
+            picotm_error_set_revocable(error);
+            return -1;
+        }
+    }
+
+    return fsync_exec[self->cc_mode](fildes, cookie, error);
+}
+
+static void
+fsync_apply_noundo(int fildes, struct picotm_error* error)
+{ }
+
+static void
+fsync_apply_2pl(int fildes, struct picotm_error* error)
+{
+    int res = fsync(fildes);
+    if (res < 0) {
+        picotm_error_set_errno(error, errno);
+        return;
+    }
+}
+
+void
+dir_tx_fsync_apply(struct dir_tx* self, int fildes, int cookie,
+                   struct picotm_error* error)
+{
+    static void (* const fsync_apply[2])(int, struct picotm_error*) = {
+        fsync_apply_noundo,
+        fsync_apply_2pl
+    };
+
+    assert(fsync_apply[self->cc_mode]);
+
+    fsync_apply[self->cc_mode](fildes, error);
+}
+
+static void
+fsync_undo_2pl(int fildes, int cookie, struct picotm_error* error)
+{ }
+
+void
+dir_tx_fsync_undo(struct dir_tx* self, int fildes, int cookie,
+                  struct picotm_error* error)
+{
+    static void (* const fsync_undo[2])(int, int, struct picotm_error*) = {
+        NULL,
+        fsync_undo_2pl
+    };
+
+    assert(fsync_undo[self->cc_mode]);
+
+    fsync_undo[self->cc_mode](fildes, cookie, error);
+}

--- a/lib/modules/libc/src/fd/dir_tx.h
+++ b/lib/modules/libc/src/fd/dir_tx.h
@@ -1,0 +1,170 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <picotm/picotm-lib-ref.h>
+#include <picotm/picotm-lib-rwstate.h>
+#include <sys/queue.h>
+#include <sys/types.h>
+#include "ofd_tx.h"
+#include "picotm/picotm-libc.h"
+
+/**
+ * \cond impl || libc_impl || libc_impl_fd
+ * \ingroup libc_impl
+ * \ingroup libc_impl_fd
+ * \file
+ * \endcond
+ */
+
+struct dir;
+struct picotm_error;
+
+union fcntl_arg;
+
+/**
+ * Holds transaction-local state for a directory.
+ */
+struct dir_tx {
+
+    struct picotm_ref16 ref;
+
+    SLIST_ENTRY(dir_tx) active_list;
+
+    struct ofd_tx base;
+
+    struct dir* dir;
+
+    unsigned long flags;
+
+    struct fcntlop* fcntltab;
+    size_t          fcntltablen;
+
+    /** Concurrency-control mode */
+    enum picotm_libc_cc_mode cc_mode;
+
+    /** State of the local lock */
+    struct picotm_rwstate rwstate;
+};
+
+struct dir_tx*
+dir_tx_of_ofd_tx(struct ofd_tx* ofd_tx);
+
+/**
+ * Initialize transaction-local directory.
+ * \param   self    The instance of `struct dir` to initialize.
+ */
+void
+dir_tx_init(struct dir_tx* self);
+
+/**
+ * Uninitialize transaction-local directory.
+ * \param   self    The instance of `struct dir` to initialize.
+ */
+void
+dir_tx_uninit(struct dir_tx* self);
+
+/**
+ * Validate the local state
+ */
+void
+dir_tx_validate(struct dir_tx* self, struct picotm_error* error);
+
+/**
+ * Updates the data structures for concurrency control after a successful apply
+ */
+void
+dir_tx_update_cc(struct dir_tx* self, struct picotm_error* error);
+
+/**
+ * Clears the data structures for concurrency control after a successful undo
+ */
+void
+dir_tx_clear_cc(struct dir_tx* self, struct picotm_error* error);
+
+/**
+ * Acquire a reference on the open file description
+ */
+void
+dir_tx_ref_or_set_up(struct dir_tx* self, struct dir* dir, int fildes,
+                        unsigned long flags, struct picotm_error* error);
+
+/**
+ * Acquire a reference on the open file description
+ */
+void
+dir_tx_ref(struct dir_tx* self);
+
+/**
+ * Release reference
+ */
+void
+dir_tx_unref(struct dir_tx* self);
+
+/**
+ * Returns true if transactions hold a reference
+ */
+bool
+dir_tx_holds_ref(struct dir_tx* self);
+
+/**
+ * Prepares the open file description for commit
+ */
+void
+dir_tx_lock(struct dir_tx* self);
+
+/**
+ * Finishes commit for open file description
+ */
+void
+dir_tx_unlock(struct dir_tx* self);
+
+/*
+ * fcntl()
+ */
+
+int
+dir_tx_fcntl_exec(struct dir_tx* self, int fildes, int cmd,
+                  union fcntl_arg* arg, bool isnoundo, int* cookie,
+                  struct picotm_error* error);
+
+void
+dir_tx_fcntl_apply(struct dir_tx* self, int fildes, int cookie,
+                   struct picotm_error* error);
+
+void
+dir_tx_fcntl_undo(struct dir_tx* self, int fildes, int cookie,
+                  struct picotm_error* error);
+
+/*
+ * fsync()
+ */
+
+int
+dir_tx_fsync_exec(struct dir_tx* self, int fildes, bool isnoundo,
+                  int* cookie, struct picotm_error* error);
+
+void
+dir_tx_fsync_apply(struct dir_tx* self, int fildes, int cookie,
+                   struct picotm_error* error);
+
+void
+dir_tx_fsync_undo(struct dir_tx* self, int fildes, int cookie,
+                  struct picotm_error* error);

--- a/lib/modules/libc/src/fd/dirtab.c
+++ b/lib/modules/libc/src/fd/dirtab.c
@@ -1,0 +1,241 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "dirtab.h"
+#include <errno.h>
+#include <picotm/picotm-error.h>
+#include <picotm/picotm-lib-array.h>
+#include <picotm/picotm-lib-tab.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include "dir.h"
+#include "range.h"
+
+static struct dir       dirtab[MAXNUMFD];
+static size_t           dirtab_len = 0;
+static pthread_rwlock_t dirtab_rwlock = PTHREAD_RWLOCK_INITIALIZER;
+
+/* Destructor */
+
+static void dirtab_uninit(void) __attribute__ ((destructor));
+
+static size_t
+dirtab_dir_uninit_walk(void* dir, struct picotm_error* error)
+{
+    dir_uninit(dir);
+    return 1;
+}
+
+static void
+dirtab_uninit(void)
+{
+    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+
+    picotm_tabwalk_1(dirtab, dirtab_len, sizeof(dirtab[0]),
+                     dirtab_dir_uninit_walk, &error);
+    if (picotm_error_is_set(&error)) {
+        abort();
+    }
+
+    int err = pthread_rwlock_destroy(&dirtab_rwlock);
+    if (err) {
+        abort();
+    }
+}
+
+/* End of destructor */
+
+static void
+rdlock_dirtab(void)
+{
+    int err = pthread_rwlock_rdlock(&dirtab_rwlock);
+    if (err) {
+        abort();
+    }
+}
+
+static void
+wrlock_dirtab(void)
+{
+    int err = pthread_rwlock_wrlock(&dirtab_rwlock);
+    if (err) {
+        abort();
+    }
+}
+
+static void
+unlock_dirtab(void)
+{
+    int err = pthread_rwlock_unlock(&dirtab_rwlock);
+    if (err) {
+        abort();
+    }
+}
+
+/* requires a writer lock */
+static struct dir*
+append_empty_dir(struct picotm_error* error)
+{
+    if (dirtab_len == picotm_arraylen(dirtab)) {
+        /* Return error if not enough ids available */
+        picotm_error_set_conflicting(error, NULL);
+        return NULL;
+    }
+
+    struct dir* dir = dirtab + dirtab_len;
+
+    dir_init(dir, error);
+    if (picotm_error_is_set(error)) {
+        return NULL;
+    }
+
+    ++dirtab_len;
+
+    return dir;
+}
+
+/* requires reader lock */
+static struct dir*
+find_by_id(const struct ofdid* id)
+{
+    struct dir *dir_beg = picotm_arraybeg(dirtab);
+    const struct dir* dir_end = picotm_arrayat(dirtab, dirtab_len);
+
+    while (dir_beg < dir_end) {
+
+        const int cmp = dir_cmp_and_ref(dir_beg, id);
+        if (!cmp) {
+            return dir_beg;
+        }
+
+        ++dir_beg;
+    }
+
+    return NULL;
+}
+
+/* requires writer lock */
+static struct dir*
+search_by_id(const struct ofdid* id, int fildes, struct picotm_error* error)
+{
+    struct dir* dir_beg = picotm_arraybeg(dirtab);
+    const struct dir* dir_end = picotm_arrayat(dirtab, dirtab_len);
+
+    while (dir_beg < dir_end) {
+
+        const int cmp = dir_cmp_and_ref_or_set_up(dir_beg, id, fildes,
+                                                     error);
+        if (!cmp) {
+            if (picotm_error_is_set(error)) {
+                return NULL;
+            }
+            return dir_beg; /* set-up dir structure; return */
+        }
+
+        ++dir_beg;
+    }
+
+    return NULL;
+}
+
+struct dir*
+dirtab_ref_fildes(int fildes, bool want_new, struct picotm_error* error)
+{
+    struct ofdid id;
+    ofdid_init_from_fildes(&id, fildes, error);
+    if (picotm_error_is_set(error)) {
+        return NULL;
+    }
+
+    struct dir* dir;
+
+    /* Try to find an existing dir structure with the given id; iff
+     * a new element was not explicitly requested.
+     */
+
+    if (!want_new) {
+        rdlock_dirtab();
+
+        dir = find_by_id(&id);
+        if (dir) {
+            goto unlock; /* found dir for id; return */
+        }
+
+        unlock_dirtab();
+    }
+
+    /* Not found or new entry is requested; acquire writer lock to
+     * create a new entry in the dir table. */
+    wrlock_dirtab();
+
+    if (!want_new) {
+        /* Re-try find operation; maybe element was added meanwhile. */
+        dir = find_by_id(&id);
+        if (dir) {
+            goto unlock; /* found dir for id; return */
+        }
+    }
+
+    /* No entry with the id exists; try to set up an existing, but
+     * currently unused, dir structure.
+     */
+
+    struct ofdid empty_id;
+    ofdid_clear(&empty_id);
+
+    dir = search_by_id(&empty_id, fildes, error);
+    if (picotm_error_is_set(error)) {
+        goto err_search_by_id;
+    } else if (dir) {
+        goto unlock; /* found dir for id; return */
+    }
+
+    /* The dir table is full; create a new entry for the dir id at the
+     * end of the table.
+     */
+
+    dir = append_empty_dir(error);
+    if (picotm_error_is_set(error)) {
+        goto err_append_empty_dir;
+    }
+
+    /* To perform the setup, we must have acquired a writer lock at
+     * this point. No other transaction may interfere. */
+    dir_ref_or_set_up(dir, fildes, error);
+    if (picotm_error_is_set(error)) {
+        goto err_dir_ref_or_set_up;
+    }
+
+unlock:
+    unlock_dirtab();
+
+    return dir;
+
+err_dir_ref_or_set_up:
+err_append_empty_dir:
+err_search_by_id:
+    unlock_dirtab();
+    return NULL;
+}
+
+size_t
+dirtab_index(struct dir* dir)
+{
+    return dir - dirtab;
+}

--- a/lib/modules/libc/src/fd/dirtab.h
+++ b/lib/modules/libc/src/fd/dirtab.h
@@ -1,0 +1,55 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * \cond impl || libc_impl || libc_impl_fd
+ * \ingroup libc_impl
+ * \ingroup libc_impl_fd
+ * \file
+ * \endcond
+ */
+
+struct dir;
+struct picotm_error;
+
+/**
+ * Returns a reference to a dir structure for the given file descriptor.
+ *
+ * \param       fildes      A file descriptor.
+ * \param       want_new    True to request a new instance.
+ * \param[out]  error       Returns an error.
+ * \returns A referenced instance of `struct dir` that refers to the file
+ *          descriptor's open file description.
+ */
+struct dir*
+dirtab_ref_fildes(int fildes, bool want_new, struct picotm_error* error);
+
+/**
+ * Returns the index of a dir structure within the dir table.
+ *
+ * \param   dir An dir structure.
+ * \returns The dir structure's index in the dir table.
+ */
+size_t
+dirtab_index(struct dir* dir);

--- a/lib/modules/libc/src/fd/fildes_tx.h
+++ b/lib/modules/libc/src/fd/fildes_tx.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <sys/queue.h>
 #include "chrdev_tx.h"
+#include "dir_tx.h"
 #include "fd_event.h"
 #include "fd_tx.h"
 #include "fifo_tx.h"
@@ -41,6 +42,7 @@ struct pipeop;
 struct openop;
 
 SLIST_HEAD(chrdev_tx_slist, chrdev_tx);
+SLIST_HEAD(dir_tx_slist, dir_tx);
 SLIST_HEAD(fd_tx_slist, fd_tx);
 SLIST_HEAD(fifo_tx_slist, fifo_tx);
 SLIST_HEAD(regfile_tx_slist, regfile_tx);
@@ -55,23 +57,29 @@ struct fildes_tx {
     /** Active instances of |struct fd_tx| */
     struct fd_tx_slist  fd_tx_active_list;
 
-    struct fifo_tx fifo_tx[MAXNUMFD];
-    size_t         fifo_tx_max_index;
-
-    /** Active instances of |struct fifo_tx| */
-    struct fifo_tx_slist    fifo_tx_active_list;
-
     struct chrdev_tx chrdev_tx[MAXNUMFD];
     size_t           chrdev_tx_max_index;
 
     /** Active instances of |struct chrdev_tx| */
     struct chrdev_tx_slist    chrdev_tx_active_list;
 
+    struct fifo_tx fifo_tx[MAXNUMFD];
+    size_t         fifo_tx_max_index;
+
+    /** Active instances of |struct fifo_tx| */
+    struct fifo_tx_slist    fifo_tx_active_list;
+
     struct regfile_tx regfile_tx[MAXNUMFD];
     size_t            regfile_tx_max_index;
 
     /** Active instances of |struct regfile_tx| */
     struct regfile_tx_slist regfile_tx_active_list;
+
+    struct dir_tx dir_tx[MAXNUMFD];
+    size_t        dir_tx_max_index;
+
+    /** Active instances of |struct dir_tx| */
+    struct dir_tx_slist dir_tx_active_list;
 
     struct socket_tx  socket_tx[MAXNUMFD];
     size_t            socket_tx_max_index;

--- a/lib/modules/libc/src/libc.c
+++ b/lib/modules/libc/src/libc.c
@@ -54,6 +54,9 @@ static _Atomic enum picotm_libc_cc_mode g_file_type_cc_mode[] = {
     PICOTM_LIBC_CC_MODE_2PL,
     PICOTM_LIBC_CC_MODE_2PL,
     PICOTM_LIBC_CC_MODE_2PL,
+    PICOTM_LIBC_CC_MODE_2PL,
+    PICOTM_LIBC_CC_MODE_2PL,
+    PICOTM_LIBC_CC_MODE_2PL,
     PICOTM_LIBC_CC_MODE_2PL
 };
 


### PR DESCRIPTION
Directory support was lost during the last refactoring of the libc code; thus breaking vfs_test_1. This patch adds directories as dedicated file types.