### PR TITLE
libc: Fail with EBADF for using file from different file descriptors

### DIFF
--- a/lib/modules/libc/src/fd/ofd.c
+++ b/lib/modules/libc/src/fd/ofd.c
@@ -203,15 +203,27 @@ unlock:
     ofd_unlock(self);
 }
 
+static int
+cmp_ofd_id(const struct ofd_id* lhs, const struct ofd_id* rhs,
+           bool ne_fildes, struct picotm_error* error)
+{
+    if (ne_fildes) {
+        return ofd_id_cmp_ne_fildes(lhs, rhs, error);
+    } else {
+        return ofd_id_cmp(lhs, rhs);
+    }
+}
+
 int
 ofd_cmp_and_ref_or_set_up(struct ofd* self, const struct ofd_id* id,
-                          int fildes, struct picotm_error* error)
+                          int fildes, bool ne_fildes,
+                          struct picotm_error* error)
 {
     assert(self);
 
     ofd_wrlock(self);
 
-    int cmp = ofd_id_cmp(&self->id, id);
+    int cmp = cmp_ofd_id(&self->id, id, ne_fildes, error);
     if (cmp) {
         goto unlock; /* ids are not equal; only return */
     }
@@ -232,13 +244,14 @@ err_ref_or_set_up:
 }
 
 int
-ofd_cmp_and_ref(struct ofd* self, const struct ofd_id* id)
+ofd_cmp_and_ref(struct ofd* self, const struct ofd_id* id, bool ne_fildes,
+                struct picotm_error* error)
 {
     assert(self);
 
     ofd_rdlock(self);
 
-    int cmp = ofd_id_cmp(&self->id, id);
+    int cmp = cmp_ofd_id(&self->id, id, ne_fildes, error);
     if (!cmp) {
         ofd_ref(self);
     }

--- a/lib/modules/libc/src/fd/ofd.h
+++ b/lib/modules/libc/src/fd/ofd.h
@@ -121,24 +121,31 @@ ofd_unref(struct ofd* self);
  * \param       self        The open file description.
  * \param       id          The id to compare to.
  * \param       fildes      A file descriptor for the setup.
+ * \param       ne_fildes   True to request non-equal file descriptors, false
+ *                          otherwise.
  * \param[out]  error       Returns an error ot the caller.
  * \returns A value less than, equal to, or greater than if the ofd's id is
  *          less than, equal to, or greater than the given id.
  */
 int
 ofd_cmp_and_ref_or_set_up(struct ofd* self, const struct ofd_id* id,
-                          int fildes, struct picotm_error* error);
+                          int fildes, bool ne_fildes,
+                          struct picotm_error* error);
 
 /**
  * \brief Compares the open file description's id to a reference id and
  *        acquires a reference if both id's are equal.
- * \param   self    The open file description.
- * \param   id      The id to compare to.
+ * \param       self        The open file description.
+ * \param       id          The id to compare to.
+ * \param       ne_fildes   True to request non-equal file descriptors, false
+ *                          otherwise.
+ * \param[out]  error       Returns an error ot the caller.
  * \returns A value less than, equal to, or greater than if the ofd's id is
  *          less than, equal to, or greater than the given id.
  */
 int
-ofd_cmp_and_ref(struct ofd* self, const struct ofd_id* id);
+ofd_cmp_and_ref(struct ofd* self, const struct ofd_id* id, bool ne_fildes,
+                struct picotm_error* error);
 
 /**
  * \brief Tries to acquire a reader lock on an open file description.

--- a/lib/modules/libc/src/fd/ofd_id.h
+++ b/lib/modules/libc/src/fd/ofd_id.h
@@ -99,3 +99,17 @@ ofd_id_clear(struct ofd_id* self);
  */
 int
 ofd_id_cmp(const struct ofd_id* lhs, const struct ofd_id* rhs);
+
+/**
+ * \brief Compares two open-file-description ids with different file
+ *        descriptors.
+ * \param       lhs     An open-file-description id.
+ * \param       rhs     An open-file-description id.
+ * \param[out]  error   Returns an error to the caller.
+ * \returns A value less than, equal to, or greater than 0 if the file id
+ *          of lhs is less than, equal to, or greater than the file id of
+ *          rhs.
+ */
+int
+ofd_id_cmp_ne_fildes(const struct ofd_id* lhs, const struct ofd_id* rhs,
+                     struct picotm_error* error);

--- a/lib/modules/libc/src/fd/ofdtab.h
+++ b/lib/modules/libc/src/fd/ofdtab.h
@@ -42,6 +42,20 @@ struct ofd;
  * \param[out]  error           Returns an error.
  * \returns A referenced instance of `struct ofd` that refers to the file
  *          descriptor's open file description.
+ *
+ * We cannot distiguish between open file descriptions. Two
+ * file descriptors refering to the same buffer might share
+ * the same open file description, or not.
+ *
+ * As a workaround, we only allow one file descriptor per file
+ * buffer at the same time. If we see a second file descriptor
+ * refering to a buffer that is already in use, the look-up
+ * fails.
+ *
+ * For a solution, Linux (or any other Unix) has to provide a
+ * unique id for each open file description, or at least give
+ * us a way of figuring out the relationship between file descriptors
+ * and open file descriptions.
  */
 struct ofd*
 ofdtab_ref_fildes(int fildes, bool newly_created, struct picotm_error* error);

--- a/tests/src/fdio_test.c
+++ b/tests/src/fdio_test.c
@@ -619,17 +619,17 @@ fdio_test_8(unsigned int tid)
 
         close_tx(fildes);
 
-        /* Close pipe */
-
-        for (size_t i = 0; i < arraylen(pfd); ++i) {
-            close_tx(pfd[i]);
-        }
-
     picotm_commit
 
         abort_transaction_on_error(__func__);
 
     picotm_end
+
+    /* Close pipe */
+
+    for (size_t i = 0; i < arraylen(pfd); ++i) {
+        close(pfd[i]);
+    }
 }
 
 void
@@ -940,17 +940,9 @@ fdio_test_14_post(unsigned long nthreads, enum loop_mode loop,
 void
 fdio_test_15(unsigned int tid)
 {
-    int fildes = TEMP_FAILURE_RETRY(open(g_filename,
-                                         O_WRONLY | O_CREAT,
-                                         S_IRWXU | S_IRWXG | S_IRWXO));
-    if (fildes < 0) {
-        perror("open");
-        abort();
-    }
-
     picotm_begin
 
-        int fildes2 = dup_tx(fildes);
+        int fildes2 = dup_tx(g_fildes);
 
         delay_transaction(tid);
 
@@ -961,11 +953,6 @@ fdio_test_15(unsigned int tid)
         abort_transaction_on_error(__func__);
 
     picotm_end
-
-    if (TEMP_FAILURE_RETRY(close(fildes)) < 0) {
-        perror("close");
-        abort();
-    }
 }
 
 void
@@ -973,7 +960,7 @@ fdio_test_15_pre(unsigned long nthreads, enum loop_mode loop,
                  enum boundary_type btype, unsigned long long bound,
                  int (*logmsg)(const char*, ...))
 {
-    temp_filename(15, 0);
+    g_fildes = temp_fildes(14, 0, O_CLOEXEC | O_WRONLY);
 }
 
 void
@@ -981,6 +968,7 @@ fdio_test_15_post(unsigned long nthreads, enum loop_mode loop,
                   enum boundary_type btype, unsigned long long bound,
                   int (*logmsg)(const char*, ...))
 {
+    close_fildes(g_fildes);
     remove_file(g_filename);
 }
 


### PR DESCRIPTION
Using the same file with different file descriptors concurrently will
now abort the transaction with an EBADF errno code. This limitation
guarantees consistency of the involved open file descriptions.

There's an exception for file descriptors created with in a transaction
(e.g., by open() or dup()). These are allowed to refer to existing file
buffer, because we know which open file description is involved.

This patch adapts test cases fdio-8 and fdio-15 to work with the new
semantics.