### PR TITLE
Remove calls to abort()

### DIFF
--- a/lib/include/picotm/picotm-lib-shared-ref-obj.h
+++ b/lib/include/picotm/picotm-lib-shared-ref-obj.h
@@ -49,9 +49,10 @@
  * An instance of `picotm_shared_ref16_obj` is initialized with a call
  * to `picotm_shared_ref16_obj_init()` and cleaned up with a call to
  * `picotm_shared_ref16_obj_uninit()`. These functions receive an instance
- * of `struct picotm_shared_ref16_obj` and an instance of
- * `struct picotm_error`, which returns error state. These functions are
- * called in the init and un-init functions of the parent class.
+ * of `struct picotm_shared_ref16_obj` and the init function also receives
+ * an instance of `struct picotm_error`, which returns error state. These
+ * functions are called in the init and un-init functions of the parent
+ * class.
  *
  * ~~~ c
  *      void
@@ -71,23 +72,20 @@
  *
  * ~~~ c
  *      void
- *      ref_counted_uninit(struct ref_counted* self, struct picotm_error* error)
+ *      ref_counted_uninit(struct ref_counted* self)
  *      {
  *          // additional clean-up code
  *
- *          picotm_shared_ref16_obj_uninit(&self->ref_obj, error);
+ *          picotm_shared_ref16_obj_uninit(&self->ref_obj);
  *          if (picotm_error_is_set(error)) {
  *              return;
  *          }
  *      }
  * ~~~
  *
- * The clean-up code may return an error in extreme situations, but such
- * errors are marked as non-recoverable.
- *
  * References to an object are acquired with a call to
  * `picotm_shared_ref16_obj_up()`. The parameters of the function consist
- * of and instance of `struc tpicotm_shared_ref16_obj`, additional user data,
+ * of and instance of `struct picotm_shared_ref16_obj`, additional user data,
  * an optional conditional function, and optional initializer function and
  * in instance of `struct picotm_error`, which returns an error state to the
  * caller.
@@ -166,10 +164,10 @@
  *      }
  *
  *      void
- *      ref_counted_down(struct ref_counted* self, struct picotm_error* error)
+ *      ref_counted_down(struct ref_counted* self)
  *      {
  *          picotm_shared_ref16_obj_down(&self->ref_obj, NULL, down_cond,
- *                                       final_ref, error);
+ *                                       final_ref);
  *      }
  * ~~~
  */
@@ -235,12 +233,10 @@ picotm_shared_ref16_obj_init(struct picotm_shared_ref16_obj* self,
 
 /**
  * Uninitializes a shared-ref16 object.
- * \param       self    The shared-ref16 object.
- * \param[out]  error   Returns an error to the caller.
+ * \param   self    The shared-ref16 object.
  */
 void
-picotm_shared_ref16_obj_uninit(struct picotm_shared_ref16_obj* self,
-                               struct picotm_error* error);
+picotm_shared_ref16_obj_uninit(struct picotm_shared_ref16_obj* self);
 
 /**
  * Acquires a reference on the shared-ref16 object.
@@ -264,13 +260,12 @@ picotm_shared_ref16_obj_up(struct picotm_shared_ref16_obj* self, void* data,
 
 /**
  * Releases a reference on the shared-ref16 object.
- * \param       self        The shared-ref16 object.
- * \param       data        User data.
- * \param       cond        An optional condition to test if the reference should
- *                          be released.
- * \param       final_ref   An optional function to finalize the object when
- *                          the final reference gets released.
- * \param[out]  error       Returns an error to the caller.
+ * \param   self        The shared-ref16 object.
+ * \param   data        User data.
+ * \param   cond        An optional condition to test if the reference should
+ *                      be released.
+ * \param   final_ref   An optional function to finalize the object when
+ *                      the final reference gets released.
  *
  * The conditional and finalizer functions are synchronized with the
  * reference counter. The down function internally locks the shared-ref16
@@ -279,7 +274,6 @@ picotm_shared_ref16_obj_up(struct picotm_shared_ref16_obj* self, void* data,
 void
 picotm_shared_ref16_obj_down(struct picotm_shared_ref16_obj* self, void* data,
                              picotm_shared_ref16_obj_condition_function cond,
-                             picotm_shared_ref16_obj_final_ref_function final_ref,
-                             struct picotm_error* error);
+                             picotm_shared_ref16_obj_final_ref_function final_ref);
 
 PICOTM_END_DECLS

--- a/lib/modules/libc/src/fildes/chrdev.c
+++ b/lib/modules/libc/src/fildes/chrdev.c
@@ -122,15 +122,13 @@ chrdev_ref_or_set_up(struct chrdev* self, int fildes,
 }
 
 void
-chrdev_ref(struct chrdev* self)
+chrdev_ref(struct chrdev* self, struct picotm_error* error)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
+    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, error);
+    if (picotm_error_is_set(error)) {
+        return;
     }
 }
 

--- a/lib/modules/libc/src/fildes/chrdev.c
+++ b/lib/modules/libc/src/fildes/chrdev.c
@@ -73,12 +73,7 @@ chrdev_uninit(struct chrdev* self)
     uninit_rwlocks(picotm_arraybeg(self->rwlock),
                    picotm_arrayend(self->rwlock));
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_uninit(&self->ref_obj, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_uninit(&self->ref_obj);
 }
 
 /*
@@ -157,13 +152,7 @@ chrdev_unref(struct chrdev* self)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref,
-                                 &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref);
 }
 
 static bool

--- a/lib/modules/libc/src/fildes/chrdev.h
+++ b/lib/modules/libc/src/fildes/chrdev.h
@@ -31,6 +31,7 @@
  * \endcond
  */
 
+struct picotm_error;
 struct picotm_rwstate;
 
 /**
@@ -86,10 +87,11 @@ chrdev_ref_or_set_up(struct chrdev* self, int fildes,
 
 /**
  * \brief Acquires a reference on an instance of `struct chrdev`.
- * \param   self    The chrdev instance.
+ * \param       self    The chrdev instance.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
-chrdev_ref(struct chrdev* self);
+chrdev_ref(struct chrdev* self, struct picotm_error* error);
 
 /**
  * \brief Compares the chrdev's id to an id and acquires a reference if both

--- a/lib/modules/libc/src/fildes/chrdev_tx.c
+++ b/lib/modules/libc/src/fildes/chrdev_tx.c
@@ -589,7 +589,10 @@ chrdev_tx_ref_or_set_up(struct chrdev_tx* self, struct chrdev* chrdev,
     }
 
     /* acquire reference on character device */
-    chrdev_ref(chrdev);
+    chrdev_ref(chrdev, error);
+    if (picotm_error_is_set(error)) {
+        goto err_chrdev_ref;
+    }
 
     /* setup fields */
 
@@ -600,6 +603,11 @@ chrdev_tx_ref_or_set_up(struct chrdev_tx* self, struct chrdev* chrdev,
     self->fcntltablen = 0;
     self->wrtablen = 0;
     self->wrbuflen = 0;
+
+    return;
+
+err_chrdev_ref:
+    picotm_ref_down(&self->ref);
 }
 
 void

--- a/lib/modules/libc/src/fildes/chrdev_tx.c
+++ b/lib/modules/libc/src/fildes/chrdev_tx.c
@@ -45,9 +45,9 @@ chrdev_tx_of_file_tx(struct file_tx* file_tx)
 }
 
 static void
-ref(struct file_tx* file_tx)
+ref(struct file_tx* file_tx, struct picotm_error* error)
 {
-    chrdev_tx_ref(chrdev_tx_of_file_tx(file_tx));
+    chrdev_tx_ref(chrdev_tx_of_file_tx(file_tx), error);
 }
 
 static void
@@ -603,7 +603,7 @@ chrdev_tx_ref_or_set_up(struct chrdev_tx* self, struct chrdev* chrdev,
 }
 
 void
-chrdev_tx_ref(struct chrdev_tx* self)
+chrdev_tx_ref(struct chrdev_tx* self, struct picotm_error* error)
 {
     picotm_ref_up(&self->ref);
 }

--- a/lib/modules/libc/src/fildes/chrdev_tx.h
+++ b/lib/modules/libc/src/fildes/chrdev_tx.h
@@ -89,7 +89,7 @@ chrdev_tx_ref_or_set_up(struct chrdev_tx* self, struct chrdev* chrdev,
  * Acquire a reference on the open file description
  */
 void
-chrdev_tx_ref(struct chrdev_tx* self);
+chrdev_tx_ref(struct chrdev_tx* self, struct picotm_error* error);
 
 /**
  * Release reference

--- a/lib/modules/libc/src/fildes/chrdevtab.c
+++ b/lib/modules/libc/src/fildes/chrdevtab.c
@@ -22,6 +22,7 @@
 #include <picotm/picotm-error.h>
 #include <picotm/picotm-lib-array.h>
 #include <picotm/picotm-lib-tab.h>
+#include <picotm/picotm-module.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include "chrdev.h"
@@ -62,30 +63,39 @@ chrdevtab_uninit(void)
 /* End of destructor */
 
 static void
-rdlock_chrdevtab(void)
+rdlock_chrdevtab(struct picotm_error* error)
 {
     int err = pthread_rwlock_rdlock(&chrdevtab_rwlock);
     if (err) {
-        abort();
+        picotm_error_set_errno(error, err);
+        return;
     }
 }
 
 static void
-wrlock_chrdevtab(void)
+wrlock_chrdevtab(struct picotm_error* error)
 {
     int err = pthread_rwlock_wrlock(&chrdevtab_rwlock);
     if (err) {
-        abort();
+        picotm_error_set_errno(error, err);
+        return;
     }
 }
 
 static void
 unlock_chrdevtab(void)
 {
-    int err = pthread_rwlock_unlock(&chrdevtab_rwlock);
-    if (err) {
-        abort();
-    }
+    do {
+        int err = pthread_rwlock_unlock(&chrdevtab_rwlock);
+        if (err) {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_error_set_errno(&error, err);
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
 }
 
 /* requires a writer lock */
@@ -166,7 +176,10 @@ chrdevtab_ref_fildes(int fildes, struct picotm_error* error)
     /* Try to find an existing chrdev structure with the given id.
      */
 
-    rdlock_chrdevtab();
+    rdlock_chrdevtab(error);
+    if (picotm_error_is_set(error)) {
+        return NULL;
+    }
 
     struct chrdev* chrdev = find_by_id(&id);
     if (chrdev) {
@@ -179,7 +192,10 @@ chrdevtab_ref_fildes(int fildes, struct picotm_error* error)
      * the chrdev table.
      */
 
-    wrlock_chrdevtab();
+    wrlock_chrdevtab(error);
+    if (picotm_error_is_set(error)) {
+        return NULL;
+    }
 
     /* Re-try find operation; maybe element was added meanwhile. */
     chrdev = find_by_id(&id);

--- a/lib/modules/libc/src/fildes/chrdevtab.c
+++ b/lib/modules/libc/src/fildes/chrdevtab.c
@@ -24,7 +24,6 @@
 #include <picotm/picotm-lib-tab.h>
 #include <picotm/picotm-module.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include "chrdev.h"
 #include "range.h"
 
@@ -50,14 +49,8 @@ chrdevtab_uninit(void)
 
     picotm_tabwalk_1(chrdevtab, chrdevtab_len, sizeof(chrdevtab[0]),
                      chrdevtab_chrdev_uninit_walk, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
 
-    int err = pthread_rwlock_destroy(&chrdevtab_rwlock);
-    if (err) {
-        abort();
-    }
+    pthread_rwlock_destroy(&chrdevtab_rwlock);
 }
 
 /* End of destructor */

--- a/lib/modules/libc/src/fildes/dir.c
+++ b/lib/modules/libc/src/fildes/dir.c
@@ -73,12 +73,7 @@ dir_uninit(struct dir* self)
     uninit_rwlocks(picotm_arraybeg(self->rwlock),
                    picotm_arrayend(self->rwlock));
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_uninit(&self->ref_obj, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_uninit(&self->ref_obj);
 }
 
 /*
@@ -156,13 +151,7 @@ dir_unref(struct dir* self)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref,
-                                 &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref);
 }
 
 static bool

--- a/lib/modules/libc/src/fildes/dir.c
+++ b/lib/modules/libc/src/fildes/dir.c
@@ -121,15 +121,13 @@ dir_ref_or_set_up(struct dir* self, int fildes, struct picotm_error* error)
 }
 
 void
-dir_ref(struct dir* self)
+dir_ref(struct dir* self, struct picotm_error* error)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
+    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, error);
+    if (picotm_error_is_set(error)) {
+        return;
     }
 }
 

--- a/lib/modules/libc/src/fildes/dir.h
+++ b/lib/modules/libc/src/fildes/dir.h
@@ -31,6 +31,7 @@
  * \endcond
  */
 
+struct picotm_error;
 struct picotm_rwstate;
 
 /**
@@ -84,10 +85,11 @@ dir_ref_or_set_up(struct dir* self, int fildes, struct picotm_error* error);
 
 /**
  * \brief Acquires a reference on an instance of `struct dir`.
- * \param   self    The dir instance.
+ * \param       self    The dir instance.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
-dir_ref(struct dir* self);
+dir_ref(struct dir* self, struct picotm_error* error);
 
 /**
  * \brief Compares the dir's id to an id and acquires a reference if both

--- a/lib/modules/libc/src/fildes/dir_tx.c
+++ b/lib/modules/libc/src/fildes/dir_tx.c
@@ -477,7 +477,10 @@ dir_tx_ref_or_set_up(struct dir_tx* self, struct dir* dir,
     }
 
     /* acquire reference on directory */
-    dir_ref(dir);
+    dir_ref(dir, error);
+    if (picotm_error_is_set(error)) {
+        goto err_dir_ref;
+    }
 
     /* setup fields */
 
@@ -491,6 +494,11 @@ dir_tx_ref_or_set_up(struct dir_tx* self, struct dir* dir,
 
     self->fchmodtablen = 0;
     self->fcntltablen = 0;
+
+    return;
+
+err_dir_ref:
+    picotm_ref_down(&self->ref);
 }
 
 void

--- a/lib/modules/libc/src/fildes/dir_tx.c
+++ b/lib/modules/libc/src/fildes/dir_tx.c
@@ -63,9 +63,9 @@ dir_tx_try_wrlock_field(struct dir_tx* self, enum dir_field field,
 }
 
 static void
-ref(struct file_tx* file_tx)
+ref(struct file_tx* file_tx, struct picotm_error* error)
 {
-    dir_tx_ref(dir_tx_of_file_tx(file_tx));
+    dir_tx_ref(dir_tx_of_file_tx(file_tx), error);
 }
 
 static void
@@ -494,7 +494,7 @@ dir_tx_ref_or_set_up(struct dir_tx* self, struct dir* dir,
 }
 
 void
-dir_tx_ref(struct dir_tx* self)
+dir_tx_ref(struct dir_tx* self, struct picotm_error* error)
 {
     picotm_ref_up(&self->ref);
 }

--- a/lib/modules/libc/src/fildes/dir_tx.h
+++ b/lib/modules/libc/src/fildes/dir_tx.h
@@ -85,7 +85,7 @@ dir_tx_ref_or_set_up(struct dir_tx* self, struct dir* dir,
  * Acquire a reference on the open file description
  */
 void
-dir_tx_ref(struct dir_tx* self);
+dir_tx_ref(struct dir_tx* self, struct picotm_error* error);
 
 /**
  * Release reference

--- a/lib/modules/libc/src/fildes/dirtab.c
+++ b/lib/modules/libc/src/fildes/dirtab.c
@@ -24,7 +24,6 @@
 #include <picotm/picotm-lib-tab.h>
 #include <picotm/picotm-module.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include "dir.h"
 #include "range.h"
 
@@ -50,14 +49,8 @@ dirtab_uninit(void)
 
     picotm_tabwalk_1(dirtab, dirtab_len, sizeof(dirtab[0]),
                      dirtab_dir_uninit_walk, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
 
-    int err = pthread_rwlock_destroy(&dirtab_rwlock);
-    if (err) {
-        abort();
-    }
+    pthread_rwlock_destroy(&dirtab_rwlock);
 }
 
 /* End of destructor */

--- a/lib/modules/libc/src/fildes/fd.c
+++ b/lib/modules/libc/src/fildes/fd.c
@@ -77,12 +77,7 @@ fd_uninit(struct fd* self)
     uninit_rwlocks(picotm_arraybeg(self->rwlock),
                    picotm_arrayend(self->rwlock));
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_uninit(&self->ref_obj, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_uninit(&self->ref_obj);
 }
 
 void
@@ -231,12 +226,7 @@ fd_unref(struct fd* self)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref);
 }
 
 void

--- a/lib/modules/libc/src/fildes/fd_tx.c
+++ b/lib/modules/libc/src/fildes/fd_tx.c
@@ -558,7 +558,7 @@ fd_tx_fcntl_exec(struct fd_tx* self, int fildes, int cmd,
                                     &self->fcntltablen, cmd, arg, &oldvalue,
                                     error);
         if (picotm_error_is_set(error)) {
-            abort();
+            goto err_cmd;
         }
     }
 

--- a/lib/modules/libc/src/fildes/fd_tx.c
+++ b/lib/modules/libc/src/fildes/fd_tx.c
@@ -130,13 +130,18 @@ fd_tx_ref_or_set_up(struct fd_tx* self, struct fd* fd, struct ofd_tx* ofd_tx,
         goto err_fd_ref;
     }
 
-    ofd_tx_ref(ofd_tx);
+    ofd_tx_ref(ofd_tx, error);
+    if (picotm_error_is_set(error)) {
+        goto err_ofd_tx_ref;
+    }
 
     self->fd = fd;
     self->ofd_tx = ofd_tx;
 
     return;
 
+err_ofd_tx_ref:
+    fd_unref(fd);
 err_fd_ref:
     picotm_ref_down(&self->ref);
 }

--- a/lib/modules/libc/src/fildes/fdtab.c
+++ b/lib/modules/libc/src/fildes/fdtab.c
@@ -25,7 +25,6 @@
 #include <picotm/picotm-lib-tab.h>
 #include <picotm/picotm-module.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include "fd.h"
 
 static struct fd                fdtab[MAXNUMFD];
@@ -51,9 +50,8 @@ fdtab_uninit(void)
 
     picotm_tabwalk_1(fdtab, sizeof(fdtab)/sizeof(fdtab[0]), sizeof(fdtab[0]),
                      fdtab_fd_uninit_walk, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+
+    pthread_rwlock_destroy(&fdtab_rwlock);
 }
 
 /* End of destructor */

--- a/lib/modules/libc/src/fildes/fdtab.c
+++ b/lib/modules/libc/src/fildes/fdtab.c
@@ -88,7 +88,7 @@ unlock_fdtab(void)
 static struct fd*
 find_by_id(int fildes, struct picotm_error* error)
 {
-    if ((ssize_t)fdtab_len <= fildes) {
+    if (fdtab_len <= (size_t)fildes) {
         return NULL;
     }
 

--- a/lib/modules/libc/src/fildes/fifo.c
+++ b/lib/modules/libc/src/fildes/fifo.c
@@ -73,12 +73,7 @@ fifo_uninit(struct fifo* self)
     uninit_rwlocks(picotm_arraybeg(self->rwlock),
                    picotm_arrayend(self->rwlock));
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_uninit(&self->ref_obj, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_uninit(&self->ref_obj);
 }
 
 /*
@@ -156,13 +151,7 @@ fifo_unref(struct fifo* self)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref,
-                                 &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref);
 }
 
 static bool

--- a/lib/modules/libc/src/fildes/fifo.c
+++ b/lib/modules/libc/src/fildes/fifo.c
@@ -121,15 +121,13 @@ fifo_ref_or_set_up(struct fifo* self, int fildes, struct picotm_error* error)
 }
 
 void
-fifo_ref(struct fifo* self)
+fifo_ref(struct fifo* self, struct picotm_error* error)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
+    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, error);
+    if (picotm_error_is_set(error)) {
+        return;
     }
 }
 

--- a/lib/modules/libc/src/fildes/fifo.h
+++ b/lib/modules/libc/src/fildes/fifo.h
@@ -31,6 +31,7 @@
  * \endcond
  */
 
+struct picotm_error;
 struct picotm_rwstate;
 
 /**
@@ -86,10 +87,11 @@ fifo_ref_or_set_up(struct fifo* self, int fildes, struct picotm_error* error);
 
 /**
  * \brief Acquires a reference on an instance of `struct fifo`.
- * \param   self    The FIFO instance.
+ * \param       self    The FIFO instance.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
-fifo_ref(struct fifo* self);
+fifo_ref(struct fifo* self, struct picotm_error* error);
 
 /**
  * \brief Compares the FIFO's id to an id and acquires a reference if both

--- a/lib/modules/libc/src/fildes/fifo_tx.c
+++ b/lib/modules/libc/src/fildes/fifo_tx.c
@@ -588,7 +588,10 @@ fifo_tx_ref_or_set_up(struct fifo_tx* self, struct fifo* fifo,
     }
 
     /* get reference on FIFO */
-    fifo_ref(fifo);
+    fifo_ref(fifo, error);
+    if (picotm_error_is_set(error)) {
+        goto err_fifo_ref;
+    }
 
     /* setup fields */
 
@@ -599,6 +602,11 @@ fifo_tx_ref_or_set_up(struct fifo_tx* self, struct fifo* fifo,
     self->fcntltablen = 0;
     self->wrtablen = 0;
     self->wrbuflen = 0;
+
+    return;
+
+err_fifo_ref:
+    picotm_ref_down(&self->ref);
 }
 
 void

--- a/lib/modules/libc/src/fildes/fifo_tx.c
+++ b/lib/modules/libc/src/fildes/fifo_tx.c
@@ -45,9 +45,9 @@ fifo_tx_of_file_tx(struct file_tx* file_tx)
 }
 
 static void
-ref(struct file_tx* file_tx)
+ref(struct file_tx* file_tx, struct picotm_error* error)
 {
-    fifo_tx_ref(fifo_tx_of_file_tx(file_tx));
+    fifo_tx_ref(fifo_tx_of_file_tx(file_tx), error);
 }
 
 static void
@@ -602,7 +602,7 @@ fifo_tx_ref_or_set_up(struct fifo_tx* self, struct fifo* fifo,
 }
 
 void
-fifo_tx_ref(struct fifo_tx* self)
+fifo_tx_ref(struct fifo_tx* self, struct picotm_error* error)
 {
     picotm_ref_up(&self->ref);
 }

--- a/lib/modules/libc/src/fildes/fifo_tx.h
+++ b/lib/modules/libc/src/fildes/fifo_tx.h
@@ -87,7 +87,7 @@ fifo_tx_ref_or_set_up(struct fifo_tx* self, struct fifo* fifo,
  * Acquire a reference on the open file description
  */
 void
-fifo_tx_ref(struct fifo_tx* self);
+fifo_tx_ref(struct fifo_tx* self, struct picotm_error* error);
 
 /**
  * Release reference

--- a/lib/modules/libc/src/fildes/fifotab.c
+++ b/lib/modules/libc/src/fildes/fifotab.c
@@ -24,7 +24,6 @@
 #include <picotm/picotm-lib-tab.h>
 #include <picotm/picotm-module.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include "fifo.h"
 #include "range.h"
 
@@ -50,14 +49,8 @@ fifotab_uninit(void)
 
     picotm_tabwalk_1(fifotab, fifotab_len, sizeof(fifotab[0]),
                      fifotab_fifo_uninit_walk, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
 
-    int err = pthread_rwlock_destroy(&fifotab_rwlock);
-    if (err) {
-        abort();
-    }
+    pthread_rwlock_destroy(&fifotab_rwlock);
 }
 
 /* End of destructor */

--- a/lib/modules/libc/src/fildes/file_tx.c
+++ b/lib/modules/libc/src/fildes/file_tx.c
@@ -46,11 +46,11 @@ file_tx_file_type(const struct file_tx* self)
 }
 
 void
-file_tx_ref(struct file_tx* self)
+file_tx_ref(struct file_tx* self, struct picotm_error* error)
 {
     assert(self);
 
-    self->ops->ref(self);
+    self->ops->ref(self, error);
 }
 
 void

--- a/lib/modules/libc/src/fildes/file_tx.h
+++ b/lib/modules/libc/src/fildes/file_tx.h
@@ -66,14 +66,16 @@ file_tx_file_type(const struct file_tx* self);
 
 /**
  * Acquire a reference on a file transaction.
- * \param   self    A file transaction.
+ * \param       self    A file transaction.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
-file_tx_ref(struct file_tx* self);
+file_tx_ref(struct file_tx* self, struct picotm_error* error);
 
 /**
  * Release a reference on a file transaction.
- * \param   self    A file transaction.
+ * \param       self    A file transaction.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
 file_tx_unref(struct file_tx* self);

--- a/lib/modules/libc/src/fildes/file_tx_ops.h
+++ b/lib/modules/libc/src/fildes/file_tx_ops.h
@@ -49,7 +49,7 @@ struct file_tx_ops {
      * Reference counting
      */
 
-    void (*ref)(struct file_tx*);
+    void (*ref)(struct file_tx*, struct picotm_error*);
     void (*unref)(struct file_tx*);
 
     /*

--- a/lib/modules/libc/src/fildes/ofd.c
+++ b/lib/modules/libc/src/fildes/ofd.c
@@ -74,12 +74,7 @@ ofd_uninit(struct ofd* self)
 
     ofd_id_uninit(&self->id);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_uninit(&self->ref_obj, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_uninit(&self->ref_obj);
 }
 
 /*
@@ -156,13 +151,7 @@ ofd_unref(struct ofd* self)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref,
-                                 &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref);
 }
 
 static int

--- a/lib/modules/libc/src/fildes/ofd.c
+++ b/lib/modules/libc/src/fildes/ofd.c
@@ -122,15 +122,13 @@ ofd_ref_or_set_up(struct ofd* self, int fildes, struct picotm_error* error)
 }
 
 void
-ofd_ref(struct ofd* self)
+ofd_ref(struct ofd* self, struct picotm_error* error)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
+    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, error);
+    if (picotm_error_is_set(error)) {
+        return;
     }
 }
 

--- a/lib/modules/libc/src/fildes/ofd.h
+++ b/lib/modules/libc/src/fildes/ofd.h
@@ -33,6 +33,7 @@
  * \endcond
  */
 
+struct picotm_error;
 struct picotm_rwstate;
 
 /**
@@ -76,10 +77,11 @@ ofd_uninit(struct ofd* self);
 
 /**
  * \brief Acquires a reference on an open file description.
- * \param   self    The open file description.
+ * \param       self    The open file description.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
-ofd_ref(struct ofd* self);
+ofd_ref(struct ofd* self, struct picotm_error* error);
 
 /**
  * \brief Sets up an open file description or acquires a reference

--- a/lib/modules/libc/src/fildes/ofd_tx.c
+++ b/lib/modules/libc/src/fildes/ofd_tx.c
@@ -172,7 +172,10 @@ ofd_tx_ref_or_set_up(struct ofd_tx* self, struct ofd* ofd,
     /* get references */
 
     ofd_ref(ofd);
-    file_tx_ref(file_tx);
+    file_tx_ref(file_tx, error);
+    if (picotm_error_is_set(error)) {
+        goto err_file_tx_ref;
+    }
 
     /* setup fields */
 
@@ -182,6 +185,12 @@ ofd_tx_ref_or_set_up(struct ofd_tx* self, struct ofd* ofd,
     self->offset = 0;
 
     self->seektablen = 0;
+
+    return;
+
+err_file_tx_ref:
+    ofd_unref(ofd);
+    picotm_ref_down(&self->ref);
 }
 
 void

--- a/lib/modules/libc/src/fildes/ofd_tx.c
+++ b/lib/modules/libc/src/fildes/ofd_tx.c
@@ -171,7 +171,11 @@ ofd_tx_ref_or_set_up(struct ofd_tx* self, struct ofd* ofd,
 
     /* get references */
 
-    ofd_ref(ofd);
+    ofd_ref(ofd, error);
+    if (picotm_error_is_set(error)) {
+        goto err_ofd_ref;
+    }
+
     file_tx_ref(file_tx, error);
     if (picotm_error_is_set(error)) {
         goto err_file_tx_ref;
@@ -190,6 +194,7 @@ ofd_tx_ref_or_set_up(struct ofd_tx* self, struct ofd* ofd,
 
 err_file_tx_ref:
     ofd_unref(ofd);
+err_ofd_ref:
     picotm_ref_down(&self->ref);
 }
 

--- a/lib/modules/libc/src/fildes/ofd_tx.c
+++ b/lib/modules/libc/src/fildes/ofd_tx.c
@@ -199,7 +199,7 @@ err_ofd_ref:
 }
 
 void
-ofd_tx_ref(struct ofd_tx* self)
+ofd_tx_ref(struct ofd_tx* self, struct picotm_error* error)
 {
     picotm_ref_up(&self->ref);
 }

--- a/lib/modules/libc/src/fildes/ofd_tx.h
+++ b/lib/modules/libc/src/fildes/ofd_tx.h
@@ -168,10 +168,11 @@ ofd_tx_ref_or_set_up(struct ofd_tx* self, struct ofd* ofd,
 
 /**
  * \brief Acquires a reference on the transaction-local open file description.
- * \param   self    The transaction-local open file description.
+ * \param       self    The transaction-local open file description.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
-ofd_tx_ref(struct ofd_tx* self);
+ofd_tx_ref(struct ofd_tx* self, struct picotm_error* error);
 
 /**
  * \brief Releases a reference on the transaction-local open file description.

--- a/lib/modules/libc/src/fildes/ofdtab.c
+++ b/lib/modules/libc/src/fildes/ofdtab.c
@@ -24,7 +24,6 @@
 #include <picotm/picotm-lib-tab.h>
 #include <picotm/picotm-module.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include <string.h>
 #include "range.h"
 #include "ofd.h"
@@ -51,14 +50,8 @@ ofdtab_uninit(void)
 
     picotm_tabwalk_1(ofdtab, ofdtab_len, sizeof(ofdtab[0]),
                      ofdtab_ofd_uninit_walk, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
 
-    int err = pthread_rwlock_destroy(&ofdtab_rwlock);
-    if (err) {
-        abort();
-    }
+    pthread_rwlock_destroy(&ofdtab_rwlock);
 }
 
 /* End of destructor */

--- a/lib/modules/libc/src/fildes/regfile.c
+++ b/lib/modules/libc/src/fildes/regfile.c
@@ -90,12 +90,7 @@ regfile_uninit(struct regfile* self)
     uninit_rwlocks(picotm_arraybeg(self->rwlock),
                    picotm_arrayend(self->rwlock));
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_uninit(&self->ref_obj, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_uninit(&self->ref_obj);
 }
 
 /*
@@ -174,13 +169,7 @@ regfile_unref(struct regfile* self)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref,
-                                 &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref);
 }
 
 static bool

--- a/lib/modules/libc/src/fildes/regfile.c
+++ b/lib/modules/libc/src/fildes/regfile.c
@@ -139,15 +139,13 @@ regfile_ref_or_set_up(struct regfile* self, int fildes,
 }
 
 void
-regfile_ref(struct regfile* self)
+regfile_ref(struct regfile* self, struct picotm_error* error)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
+    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, error);
+    if (picotm_error_is_set(error)) {
+        return;
     }
 }
 

--- a/lib/modules/libc/src/fildes/regfile.c
+++ b/lib/modules/libc/src/fildes/regfile.c
@@ -23,7 +23,6 @@
 #include <picotm/picotm-lib-array.h>
 #include <picotm/picotm-lib-ptr.h>
 #include <picotm/picotm-lib-rwstate.h>
-#include <stdlib.h>
 #include "rwcountermap.h"
 
 #define RECSIZE (1ul << RECBITS)
@@ -290,14 +289,8 @@ regfile_unlock_region(struct regfile* self, off_t off, size_t nbyte,
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
     rwcountermap_unlock(rwcountermap,
                         reccount(nbyte),
                         recoffset(off),
-                        &self->rwlockmap,
-                        &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+                        &self->rwlockmap);
 }

--- a/lib/modules/libc/src/fildes/regfile.h
+++ b/lib/modules/libc/src/fildes/regfile.h
@@ -32,6 +32,7 @@
  * \endcond
  */
 
+struct picotm_error;
 struct picotm_rwstate;
 struct rwcountermap;
 
@@ -91,10 +92,11 @@ regfile_ref_or_set_up(struct regfile* self, int fildes,
 
 /**
  * \brief Acquires a reference on an instance of `struct regfile`.
- * \param   self    The file instance.
+ * \param       self    The file instance.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
-regfile_ref(struct regfile* self);
+regfile_ref(struct regfile* self, struct picotm_error* error);
 
 /**
  * \brief Compares the file's id to an id and acquires a reference if both

--- a/lib/modules/libc/src/fildes/regfile_tx.c
+++ b/lib/modules/libc/src/fildes/regfile_tx.c
@@ -567,7 +567,7 @@ lseek_exec(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
                                     from, offset, whence,
                                     error);
         if (picotm_error_is_set(error)) {
-            abort();
+            return (off_t)-1;
         }
     }
 

--- a/lib/modules/libc/src/fildes/regfile_tx.c
+++ b/lib/modules/libc/src/fildes/regfile_tx.c
@@ -1287,7 +1287,10 @@ regfile_tx_ref_or_set_up(struct regfile_tx* self, struct regfile* regfile,
     }
 
     /* get reference on file */
-    regfile_ref(regfile);
+    regfile_ref(regfile, error);
+    if (picotm_error_is_set(error)) {
+        goto err_regfile_ref;
+    }
 
     /* setup fields */
 
@@ -1304,6 +1307,11 @@ regfile_tx_ref_or_set_up(struct regfile_tx* self, struct regfile* regfile,
     self->wrbuflen = 0;
 
     self->locktablen = 0;
+
+    return;
+
+err_regfile_ref:
+    picotm_ref_down(&self->ref);
 }
 
 void

--- a/lib/modules/libc/src/fildes/regfile_tx.c
+++ b/lib/modules/libc/src/fildes/regfile_tx.c
@@ -122,9 +122,9 @@ regfile_tx_of_file_tx(struct file_tx* file_tx)
 }
 
 static void
-ref(struct file_tx* file_tx)
+ref(struct file_tx* file_tx, struct picotm_error* error)
 {
-    regfile_tx_ref(regfile_tx_of_file_tx(file_tx));
+    regfile_tx_ref(regfile_tx_of_file_tx(file_tx), error);
 }
 
 static void
@@ -1307,7 +1307,7 @@ regfile_tx_ref_or_set_up(struct regfile_tx* self, struct regfile* regfile,
 }
 
 void
-regfile_tx_ref(struct regfile_tx* self)
+regfile_tx_ref(struct regfile_tx* self, struct picotm_error* error)
 {
     picotm_ref_up(&self->ref);
 }

--- a/lib/modules/libc/src/fildes/regfile_tx.h
+++ b/lib/modules/libc/src/fildes/regfile_tx.h
@@ -128,7 +128,7 @@ regfile_tx_ref_or_set_up(struct regfile_tx* self, struct regfile* regfile,
  * Acquire a reference on the open file description
  */
 void
-regfile_tx_ref(struct regfile_tx* self);
+regfile_tx_ref(struct regfile_tx* self, struct picotm_error* error);
 
 /**
  * Release reference

--- a/lib/modules/libc/src/fildes/regfiletab.c
+++ b/lib/modules/libc/src/fildes/regfiletab.c
@@ -22,6 +22,7 @@
 #include <picotm/picotm-error.h>
 #include <picotm/picotm-lib-array.h>
 #include <picotm/picotm-lib-tab.h>
+#include <picotm/picotm-module.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include "range.h"
@@ -62,30 +63,39 @@ regfiletab_uninit(void)
 /* End of destructor */
 
 static void
-rdlock_regfiletab(void)
+rdlock_regfiletab(struct picotm_error* error)
 {
     int err = pthread_rwlock_rdlock(&regfiletab_rwlock);
     if (err) {
-        abort();
+        picotm_error_set_errno(error, err);
+        return;
     }
 }
 
 static void
-wrlock_regfiletab(void)
+wrlock_regfiletab(struct picotm_error* error)
 {
     int err = pthread_rwlock_wrlock(&regfiletab_rwlock);
     if (err) {
-        abort();
+        picotm_error_set_errno(error, err);
+        return;
     }
 }
 
 static void
 unlock_regfiletab(void)
 {
-    int err = pthread_rwlock_unlock(&regfiletab_rwlock);
-    if (err) {
-        abort();
-    }
+    do {
+        int err = pthread_rwlock_unlock(&regfiletab_rwlock);
+        if (err) {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_error_set_errno(&error, err);
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
 }
 
 /* requires a writer lock */
@@ -165,12 +175,14 @@ regfiletab_ref_fildes(int fildes, struct picotm_error* error)
         return NULL;
     }
 
-
     /* Try to find an existing regfile structure with the given id; iff
      * a new element was not explicitly requested.
      */
 
-    rdlock_regfiletab();
+    rdlock_regfiletab(error);
+    if (picotm_error_is_set(error)) {
+        return NULL;
+    }
 
     struct regfile* regfile = find_by_id(&id);
     if (regfile) {
@@ -183,7 +195,10 @@ regfiletab_ref_fildes(int fildes, struct picotm_error* error)
      * the regfile table.
      */
 
-    wrlock_regfiletab();
+    wrlock_regfiletab(error);
+    if (picotm_error_is_set(error)) {
+        return NULL;
+    }
 
     /* Re-try find operation; maybe element was added meanwhile. */
     regfile = find_by_id(&id);

--- a/lib/modules/libc/src/fildes/regfiletab.c
+++ b/lib/modules/libc/src/fildes/regfiletab.c
@@ -24,7 +24,6 @@
 #include <picotm/picotm-lib-tab.h>
 #include <picotm/picotm-module.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include "range.h"
 #include "regfile.h"
 
@@ -50,14 +49,8 @@ regfiletab_uninit(void)
 
     picotm_tabwalk_1(regfiletab, regfiletab_len, sizeof(regfiletab[0]),
                      regfiletab_regfile_uninit_walk, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
 
-    int err = pthread_rwlock_destroy(&regfiletab_rwlock);
-    if (err) {
-        abort();
-    }
+    pthread_rwlock_destroy(&regfiletab_rwlock);
 }
 
 /* End of destructor */

--- a/lib/modules/libc/src/fildes/rwcountermap.h
+++ b/lib/modules/libc/src/fildes/rwcountermap.h
@@ -59,5 +59,4 @@ void
 rwcountermap_unlock(struct rwcountermap* self,
                     unsigned long long record_length,
                     unsigned long long record_offset,
-                    struct rwlockmap *rwlockmap,
-                    struct picotm_error* error);
+                    struct rwlockmap *rwlockmap);

--- a/lib/modules/libc/src/fildes/socket.c
+++ b/lib/modules/libc/src/fildes/socket.c
@@ -120,15 +120,13 @@ socket_ref_or_set_up(struct socket* self, int fildes,
 }
 
 void
-socket_ref(struct socket* self)
+socket_ref(struct socket* self, struct picotm_error* error)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
+    picotm_shared_ref16_obj_up(&self->ref_obj, NULL, NULL, NULL, error);
+    if (picotm_error_is_set(error)) {
+        return;
     }
 }
 

--- a/lib/modules/libc/src/fildes/socket.c
+++ b/lib/modules/libc/src/fildes/socket.c
@@ -71,12 +71,7 @@ socket_uninit(struct socket* self)
     uninit_rwlocks(picotm_arraybeg(self->rwlock),
                    picotm_arrayend(self->rwlock));
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_uninit(&self->ref_obj, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_uninit(&self->ref_obj);
 }
 
 /*
@@ -155,13 +150,7 @@ socket_unref(struct socket* self)
 {
     assert(self);
 
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref,
-                                 &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
+    picotm_shared_ref16_obj_down(&self->ref_obj, NULL, NULL, final_ref);
 }
 
 static bool

--- a/lib/modules/libc/src/fildes/socket.h
+++ b/lib/modules/libc/src/fildes/socket.h
@@ -31,6 +31,7 @@
  * \endcond
  */
 
+struct picotm_error;
 struct picotm_rwstate;
 
 /**
@@ -87,10 +88,11 @@ socket_ref_or_set_up(struct socket* self, int fildes,
 
 /**
  * \brief Acquires a reference on an instance of `struct socket`.
- * \param   self    The socket instance.
+ * \param       self    The socket instance.
+ * \param[out]  error   Returns an error to the caller.
  */
 void
-socket_ref(struct socket* self);
+socket_ref(struct socket* self, struct picotm_error* error);
 
 /**
  * \brief Compares the socket's id to an id and acquires a reference if both

--- a/lib/modules/libc/src/fildes/socket_tx.c
+++ b/lib/modules/libc/src/fildes/socket_tx.c
@@ -854,7 +854,10 @@ socket_tx_ref_or_set_up(struct socket_tx* self, struct socket* socket,
     }
 
     /* get reference on socket */
-    socket_ref(socket);
+    socket_ref(socket, error);
+    if (picotm_error_is_set(error)) {
+        goto err_socket_ref;
+    }
 
     /* setup fields */
 
@@ -864,6 +867,11 @@ socket_tx_ref_or_set_up(struct socket_tx* self, struct socket* socket,
     self->fcntltablen = 0;
     self->wrtablen = 0;
     self->wrbuflen = 0;
+
+    return;
+
+err_socket_ref:
+    picotm_ref_down(&self->ref);
 }
 
 void

--- a/lib/modules/libc/src/fildes/socket_tx.c
+++ b/lib/modules/libc/src/fildes/socket_tx.c
@@ -44,9 +44,9 @@ socket_tx_of_file_tx(struct file_tx* file_tx)
 }
 
 static void
-ref(struct file_tx* file_tx)
+ref(struct file_tx* file_tx, struct picotm_error* error)
 {
-    socket_tx_ref(socket_tx_of_file_tx(file_tx));
+    socket_tx_ref(socket_tx_of_file_tx(file_tx), error);
 }
 
 static void
@@ -867,7 +867,7 @@ socket_tx_ref_or_set_up(struct socket_tx* self, struct socket* socket,
 }
 
 void
-socket_tx_ref(struct socket_tx* self)
+socket_tx_ref(struct socket_tx* self, struct picotm_error* error)
 {
     picotm_ref_up(&self->ref);
 }

--- a/lib/modules/libc/src/fildes/socket_tx.h
+++ b/lib/modules/libc/src/fildes/socket_tx.h
@@ -88,7 +88,7 @@ socket_tx_ref_or_set_up(struct socket_tx* self, struct socket* socket,
  * Acquire a reference on the open file description
  */
 void
-socket_tx_ref(struct socket_tx* self);
+socket_tx_ref(struct socket_tx* self, struct picotm_error* error);
 
 /**
  * Release reference

--- a/lib/modules/libc/src/fildes/sockettab.c
+++ b/lib/modules/libc/src/fildes/sockettab.c
@@ -24,7 +24,6 @@
 #include <picotm/picotm-lib-tab.h>
 #include <picotm/picotm-module.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include "range.h"
 #include "socket.h"
 
@@ -50,14 +49,8 @@ sockettab_uninit(void)
 
     picotm_tabwalk_1(sockettab, sockettab_len, sizeof(sockettab[0]),
                      sockettab_socket_uninit_walk, &error);
-    if (picotm_error_is_set(&error)) {
-        abort();
-    }
 
-    int err = pthread_rwlock_destroy(&sockettab_rwlock);
-    if (err) {
-        abort();
-    }
+    pthread_rwlock_destroy(&sockettab_rwlock);
 }
 
 /* End of destructor */


### PR DESCRIPTION
This patch set removes all calls to abort() form the internals of picotm. These calls usually happened in clean-up code, where they have been replaced with non-recoverable errors. In other places, abort() could be replaced by regular errors or removed entirely.