### PR TITLE
tests: Update Travis CI scripts for more efficient testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,53 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-7"
 
+    # clang 3.6
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.6
+      env:
+        - MATRIX_EVAL="CC=clang-3.6 && SKIP_MAKE_CHECK=1"
+
+    # clang 3.7 not available
+
+    # clang 3.8
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.8
+      env:
+        - MATRIX_EVAL="CC=clang-3.8 && SKIP_MAKE_CHECK=1"
+
+    # clang 3.9
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.9
+      env:
+        - MATRIX_EVAL="CC=clang-3.9 && SKIP_MAKE_CHECK=1"
+
+    # clang 4.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && SKIP_MAKE_CHECK=1"
+
 before_install:
     - eval "${MATRIX_EVAL}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
           packages:
             - gcc-4.9
       env:
-         - MATRIX_EVAL="CC=gcc-4.9"
+         - MATRIX_EVAL="CC=gcc-4.9 && SKIP_MAKE_CHECK=1"
 
     # GCC 5
     - os: linux
@@ -42,7 +42,7 @@ matrix:
           packages:
             - gcc-5
       env:
-         - MATRIX_EVAL="CC=gcc-5"
+         - MATRIX_EVAL="CC=gcc-5 && SKIP_MAKE_CHECK=1"
 
     # GCC 6
     - os: linux
@@ -75,6 +75,7 @@ before_script:
         sudo make install )
 
 script:
-    - ( export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}" &&
-        cd tests &&
-        make -j1 check )
+    - ( [ -n "${SKIP_MAKE_CHECK}" ] ||
+        ( export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}" &&
+          cd tests &&
+          make -j1 check ) )

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,18 @@ matrix:
           packages:
             - gcc-6
       env:
-        - MATRIX_EVAL="CC=gcc-6"
+        - MATRIX_EVAL="CC=gcc-6 && SKIP_MAKE_CHECK=1"
+
+    # GCC 7
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7"
 
 before_install:
     - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
We build and test with 3 releases of gcc on Linux. This could probably be improved by increasing the number of compilers and reducing the number of tests.