### PR TITLE
tests: Use static linking for 'picotm-test'

### DIFF
--- a/tests/modules/Makefile.am
+++ b/tests/modules/Makefile.am
@@ -75,6 +75,8 @@ picotm_test_SOURCES = fildes_test.c \
                       vfs_test.c \
                       vfs_test.h
 
+picotm_test_LDFLAGS = -static
+
 picotm_test_LDADD = $(top_builddir)/modules/libpthread/src/libpicotm-pthread.la \
                     $(top_builddir)/modules/libm/src/libpicotm-m.la \
                     $(top_builddir)/modules/libc/src/libpicotm-c.la \


### PR DESCRIPTION
This patch enables static linking for the 'picotm-test' tool.

Dynamically linked test tools rely on script magic that is provided by
Automake. Static linking of the test tools is prefered to make the testing
process more reliable and work with tools such as valgrind.