### PR TITLE
Add 'struct picotm_spinlock'

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -25,6 +25,7 @@ nobase_include_HEADERS = picotm/compiler.h \
                          picotm/picotm-lib-rwstate.h \
                          picotm/picotm-lib-shared-treemap.h \
                          picotm/picotm-lib-shared-ref-obj.h \
+                         picotm/picotm-lib-spinlock.h \
                          picotm/picotm-lib-tab.h \
                          picotm/picotm-lib-treemap.h \
                          picotm/picotm-module.h \

--- a/include/picotm/picotm-lib-shared-ref-obj.h
+++ b/include/picotm/picotm-lib-shared-ref-obj.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <pthread.h>
 #include "compiler.h"
 #include "picotm-lib-ref.h"
+#include "picotm-lib-spinlock.h"
 
 /**
  * \ingroup group_modules
@@ -179,7 +179,7 @@ struct picotm_error;
 struct picotm_shared_ref16_obj {
 
     /** Internal lock. */
-    pthread_spinlock_t lock;
+    struct picotm_spinlock lock;
 
     /** Reference counter */
     struct picotm_shared_ref16 ref;

--- a/include/picotm/picotm-lib-spinlock.h
+++ b/include/picotm/picotm-lib-spinlock.h
@@ -1,0 +1,161 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+/**
+ * \ingroup group_modules
+ * \file
+ * \brief Contains `struct picotm_spinlock` and helper functions.
+ *
+ * The `struct picotm_spinlock` data structure provides an spin lock that is
+ * independent from the operating system. It's useful for portable modules or
+ * creating more complex data structures.
+ *
+ * The spin lock uses a very simple implementation. It's non-recursive, so
+ * a thread cannot acquire a spin lock twice at the same time. It's also not
+ * dead-lock safe. The advantage of the simple implmentation is that it
+ * cannot fail with an error.
+ *
+ * An instance of `struct picotm_spinlock` is initialized by a call
+ * to `picotm_spinlock_init()`.
+ *
+ * ~~~ c
+ *      struct picotm_spinlock lock;
+ *
+ *      spinlock_init(&lock);
+ * ~~~
+ *
+ * Alternatively, the macro `PICOTM_SPINLOCK_INITIALIZER` initializes
+ * static lock variables, or stack-allocated locks. When both, function
+ * and macro initialization, is possible, the macro form os the prefered
+ * one.
+ *
+ * ~~~ c
+ *      struct picotm_spinlock lock = PICOTM_SPINLOCK_INITIALIZER;
+ * ~~~
+ *
+ * After the initialization, the spinlock is in an unlocked state. A call
+ * to `picotm_spinlock_lock()` acquires the spin lock, and a call to
+ * `picotm_spinlock_unlock()` release the spin lock.
+ *
+ * ~~~ c
+ *      picotm_spinlock_lock(&lock);
+ *
+ *          // critical section
+ *
+ *      picotm_spinlock_unlock(&lock);
+ * ~~~
+ *
+ * A call to `picotm_spinlock_lock()` can possibly block the thread for an
+ * unbounded amount of time. A call to `picotm_spinlock_try_lock()` only
+ * tries once to acquire the lock, and returns a boolean value signalling
+ * success or failure.
+ *
+ * ~~~ c
+ *      if (picotm_spinlock_try_lock(&lock)) {
+ *
+ *              // critical section
+ *
+ *          picotm_spinlock_unlock(&lock);
+ *      }
+ * ~~~
+ *
+ * The spin lock's locking and unlocking functions act as memory barriers.
+ * Therefore load and store operations before, within, or after a critical
+ * section take effect ontheir side of the respective barrier.
+ */
+
+#include <assert.h>
+#include <stdatomic.h>
+#include "compiler.h"
+
+PICOTM_BEGIN_DECLS
+
+/**
+ * \brief Provides an operating-system-neutral, non-recursive spin-lock type.
+ */
+struct picotm_spinlock {
+    atomic_char is_locked;
+};
+
+/**
+ * \brief Initializer macro for picotm spin locks.
+ */
+#define PICOTM_SPINLOCK_INITIALIZER \
+    {                               \
+        0                           \
+    }
+
+static inline void
+picotm_spinlock_init(struct picotm_spinlock* self)
+{
+    assert(self);
+
+    self->is_locked = 0;
+}
+
+static inline void
+picotm_spinlock_uninit(struct picotm_spinlock* self)
+{
+    assert(self);
+
+    /* nothing to do */
+}
+
+static inline _Bool
+picotm_spinlock_try_lock(struct picotm_spinlock* self)
+{
+    assert(self);
+
+    char expected = 0;
+
+    return atomic_compare_exchange_strong_explicit(&self->is_locked,
+                                                   &expected, 1,
+                                                   memory_order_acq_rel,
+                                                   memory_order_acquire);
+}
+
+static inline void
+picotm_spinlock_lock(struct picotm_spinlock* self)
+{
+    assert(self);
+
+    _Bool succ;
+
+    do {
+        char expected = 0;
+
+        /* The 'weak compare-exchange' might be faster on some platforms. */
+        succ = atomic_compare_exchange_weak_explicit(&self->is_locked,
+                                                     &expected, 1,
+                                                     memory_order_acq_rel,
+                                                     memory_order_acquire);
+    } while (!succ);
+}
+
+static inline void
+picotm_spinlock_unlock(struct picotm_spinlock* self)
+{
+    assert(self);
+
+    atomic_store_explicit(&self->is_locked, 0, memory_order_release);
+}
+
+PICOTM_END_DECLS

--- a/modules/tm/src/module.c
+++ b/modules/tm/src/module.c
@@ -20,10 +20,10 @@
 #include "module.h"
 #include <assert.h>
 #include <errno.h>
-#include <pthread.h>
+#include <picotm/picotm-lib-spinlock.h>
+#include <picotm/picotm-module.h>
 #include <stdatomic.h>
 #include <stdlib.h>
-#include <picotm/picotm-module.h>
 #include "vmem.h"
 #include "vmem_tx.h"
 
@@ -51,13 +51,9 @@ get_vmem(struct picotm_error* error)
         return &g_vmem;
     }
 
-    static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+    static struct picotm_spinlock lock = PICOTM_SPINLOCK_INITIALIZER;
 
-    int res = pthread_mutex_lock(&lock);
-    if (res) {
-        picotm_error_set_errno(error, res);
-        return NULL;
-    }
+    picotm_spinlock_lock(&lock);
 
     if (atomic_load_explicit(&g_vmem_is_initialized, memory_order_acquire)) {
         /* Another transaction initialized the vmem structure
@@ -72,11 +68,8 @@ get_vmem(struct picotm_error* error)
     atomic_store_explicit(&g_vmem_is_initialized, true, memory_order_release);
 
 out:
-    res = pthread_mutex_unlock(&lock);
-    if (res) {
-        picotm_error_set_errno(error, res);
-        return NULL;
-    }
+    picotm_spinlock_unlock(&lock);
+
     return &g_vmem;
 };
 


### PR DESCRIPTION
The Pthreads API complicates error handling and does not provide statically initialized spin locks.

Having a simple spin-lock type will allow us to replace the Pthread spin lock and mutices in several places. The implementation cannot fail with errors.