### PR TITLE
Add lock manager

### DIFF
--- a/include/picotm/picotm-lib-rwlock.h
+++ b/include/picotm/picotm-lib-rwlock.h
@@ -88,7 +88,7 @@ struct picotm_error;
  * ~~~
  */
 struct picotm_rwlock {
-    /** counter variable; UINT8_T means 'exclusive writer present' */
+    /** counter variable */
     atomic_uint_least8_t  n;
 };
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,6 +35,8 @@ libpicotm_la_SOURCES = log.c \
                        picotm-lib-shared-treemap.c \
                        picotm-lib-tab.c \
                        picotm-lib-treemap.c \
+                       picotm_lock_manager.c \
+                       picotm_lock_manager.h \
                        picotm_lock_owner.c \
                        picotm_lock_owner.h \
                        picotm_os_cond.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,8 @@ libpicotm_la_SOURCES = log.c \
                        picotm-lib-treemap.c \
                        picotm_os_rwlock.c \
                        picotm_os_rwlock.h \
+                       picotm_os_timespec.c \
+                       picotm_os_timespec.h \
                        table.c \
                        table.h \
                        tx.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,6 +35,8 @@ libpicotm_la_SOURCES = log.c \
                        picotm-lib-shared-treemap.c \
                        picotm-lib-tab.c \
                        picotm-lib-treemap.c \
+                       picotm_lock_owner.c \
+                       picotm_lock_owner.h \
                        picotm_os_cond.c \
                        picotm_os_cond.h \
                        picotm_os_mutex.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,6 +35,10 @@ libpicotm_la_SOURCES = log.c \
                        picotm-lib-shared-treemap.c \
                        picotm-lib-tab.c \
                        picotm-lib-treemap.c \
+                       picotm_os_cond.c \
+                       picotm_os_cond.h \
+                       picotm_os_mutex.c \
+                       picotm_os_mutex.h \
                        picotm_os_rwlock.c \
                        picotm_os_rwlock.h \
                        picotm_os_timespec.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,6 +35,8 @@ libpicotm_la_SOURCES = log.c \
                        picotm-lib-shared-treemap.c \
                        picotm-lib-tab.c \
                        picotm-lib-treemap.c \
+                       picotm_os_rwlock.c \
+                       picotm_os_rwlock.h \
                        table.c \
                        table.h \
                        tx.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,6 +30,7 @@ libpicotm_la_SOURCES = log.c \
                        picotm.h \
                        picotm-error.c \
                        picotm-lib-rwlock.c \
+                       picotm-lib-rwlock.h \
                        picotm-lib-rwstate.c \
                        picotm-lib-shared-ref-obj.c \
                        picotm-lib-shared-treemap.c \

--- a/src/picotm-lib-rwlock.c
+++ b/src/picotm-lib-rwlock.c
@@ -17,10 +17,27 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "picotm/picotm-lib-rwlock.h"
+#include "picotm-lib-rwlock.h"
 #include <assert.h>
 #include <stdint.h>
 #include "picotm/picotm-error.h"
+#include "picotm/picotm-module.h"
+#include "picotm_lock_manager.h"
+#include "picotm_lock_owner.h"
+#include "picotm_os_timespec.h"
+
+enum {
+    /** \brief Offset of the waiter index in 'struct picotm_rwlock::n' */
+    INDEX_BIT_SHIFT = 4,
+    /** \brief Bitmask of the counter in 'struct picotm_rwlock::n' */
+    COUNTER_BIT_MASK = (1ul << INDEX_BIT_SHIFT) - 1
+};
+
+/** \brief Bitmask of the waiter index in 'struct picotm_rwlock::n' */
+static const uint8_t INDEX_BIT_MASK = ~COUNTER_BIT_MASK;
+
+/** \brief Writer is present if this counter value is set. */
+static const uint8_t WRITER_COUNTER = COUNTER_BIT_MASK;
 
 PICOTM_EXPORT
 void
@@ -38,35 +55,234 @@ picotm_rwlock_uninit(struct picotm_rwlock* self)
     assert(self);
 }
 
+static unsigned long
+get_first_index(void* slist)
+{
+    struct picotm_rwlock* rwlock = slist;
+    assert(rwlock);
+
+    return picotm_rwlock_get_index(rwlock);
+}
+
+static unsigned long
+cmpxchg_first_index(void* slist,
+                    unsigned long expected_index,
+                    unsigned long desired_index)
+{
+    struct picotm_rwlock* rwlock = slist;
+    assert(rwlock);
+
+    return picotm_rwlock_cmpxchg_index(rwlock, expected_index, desired_index);
+}
+
+static const struct picotm_lock_slist_funcs s_picotm_rwlock_slist_funcs = {
+    get_first_index,
+    cmpxchg_first_index
+};
+
+static uint8_t
+rw_counter_bits(unsigned long value)
+{
+    assert((value & COUNTER_BIT_MASK) == value);
+
+    return value & COUNTER_BIT_MASK;
+}
+
+static unsigned long
+rw_counter(uint8_t n)
+{
+    return n & COUNTER_BIT_MASK;
+}
+
+static uint8_t
+rw_index_bits(unsigned long value)
+{
+    return (value << INDEX_BIT_SHIFT) & INDEX_BIT_MASK;
+}
+
+static uint8_t
+rw_index(uint8_t n)
+{
+    return (n & INDEX_BIT_MASK) >> INDEX_BIT_SHIFT;
+}
+
+static void
+try_lock_or_wait(struct picotm_rwlock* self,
+                 bool (*try_lock)(struct picotm_rwlock*),
+                 struct picotm_error* error)
+{
+    static const struct timespec sleep_time = {0, 50};
+
+    assert(try_lock);
+
+    struct picotm_lock_owner* waiter = NULL;
+
+    unsigned int nretries = 0;
+
+    do {
+
+        bool succ = try_lock(self);
+
+        if (succ) {
+            /* We successfully acquired the lock. */
+            return;
+        } else if (waiter) {
+            /* Neither an error nor success, but we already waited
+             * for the lock to become available. This time we signal
+             * a conflict to the caller. */
+            picotm_error_set_conflicting(error, self);
+            return;
+        } else {
+
+            if (nretries) {
+                picotm_os_nanosleep(&sleep_time, error);
+                if (picotm_error_is_set(error)) {
+                    return;
+                }
+                --nretries;
+                continue;
+            }
+
+            /* Neither an error nor success as the lock is currently
+             * blocked. We wait until the lock becomes available or
+             * a timeout fires. */
+
+            assert(!waiter); /* We haven't waited already. */
+
+            waiter = picotm_lock_owner_get_thread_local_instance();
+
+            struct picotm_lock_manager* lmanager =
+                picotm_lock_owner_get_lock_manager(waiter);
+
+            picotm_lock_manager_wait(lmanager, waiter, false,
+                                     &s_picotm_rwlock_slist_funcs, self,
+                                     error);
+
+            if (picotm_error_is_set(error)) {
+                return;
+            }
+        }
+    } while (true);
+}
+
+static bool
+try_rdlock(struct picotm_rwlock* self)
+{
+    uint8_t n = atomic_load_explicit(&self->n, memory_order_acquire);
+
+    do {
+        if (rw_counter(n) == WRITER_COUNTER) {
+            /* writer present; cannot read-lock */
+            return false;
+        } else if (rw_counter(n) == (WRITER_COUNTER - 1)) {
+            /* maximum number of readers reached; cannot read-lock */
+            return false;
+        } else if (rw_index(n)) {
+            /* other transactions are already waiting; cannot read-lock */
+            return false;
+        }
+
+        uint8_t expected = rw_counter_bits(rw_counter(n));
+        uint8_t desired  = rw_counter_bits(rw_counter(n) + 1);
+
+        bool succ = atomic_compare_exchange_strong_explicit(&self->n,
+                                                            &expected, desired,
+                                                            memory_order_acq_rel,
+                                                            memory_order_acquire);
+        if (succ) {
+            return true;
+        }
+
+        n = expected;
+
+    } while (true);
+}
+
 PICOTM_EXPORT
 void
 picotm_rwlock_try_rdlock(struct picotm_rwlock* self,
                          struct picotm_error* error)
 {
+    try_lock_or_wait(self, try_rdlock, error);
+}
+
+static bool
+try_wrlock(struct picotm_rwlock* self)
+{
     assert(self);
 
+    uint8_t n = atomic_load_explicit(&self->n, memory_order_acquire);
+
     do {
-        uint8_t n = atomic_load_explicit(&self->n, memory_order_relaxed);
 
-        if (n == UINT8_MAX) {
-            /* writer present; cannot read-lock */
-            picotm_error_set_conflicting(error, self);
-            return;
-        } else if (n == (UINT8_MAX - 1)) {
-            /* maximum number of readers reached; cannot read-lock */
-            picotm_error_set_conflicting(error, self);
-            return;
+        if (rw_counter(n)) {
+            /* other transactions present; cannot write-lock */
+            return false;
+        } else if (rw_index(n)) {
+            /* other waiters are already present; cannot write-lock */
+            return false;
         }
 
-        /* The 'weak compare-exchange' might be faster on some platforms. */
-        bool succ =
-            atomic_compare_exchange_weak_explicit(&self->n, &n, n + 1,
-                                                  memory_order_relaxed,
-                                                  memory_order_relaxed);
+        /* Expect us to be the only transaction. */
+        uint8_t expected = rw_counter_bits(0);
+        uint8_t desired  = rw_counter_bits(WRITER_COUNTER);
+
+        bool succ = atomic_compare_exchange_strong_explicit(&self->n,
+                                                            &expected, desired,
+                                                            memory_order_acq_rel,
+                                                            memory_order_acquire);
         if (succ) {
-            return;
+            return true;
         }
 
+        n = expected;
+
+    } while (true);
+}
+
+static bool
+try_uplock(struct picotm_rwlock* self)
+{
+    assert(self);
+
+    uint8_t n = atomic_load_explicit(&self->n, memory_order_acquire);
+
+    do {
+
+        assert(rw_counter(n));
+
+        if (rw_counter(n) != 1) {
+            /* other transactions present; cannot write-lock */
+            return false;
+        }
+
+        /* Expect us to be the only reader if we're upgrading. Waiting
+         * transactions can be ignored as we already hold the lock in
+         * reader mode. */
+
+        uint8_t expected = rw_index_bits(rw_index(n)) |
+                           rw_counter_bits(1);
+
+        uint8_t desired = rw_index_bits(rw_index(n)) |
+                          rw_counter_bits(WRITER_COUNTER);
+
+        bool succ =
+            atomic_compare_exchange_strong_explicit(&self->n,
+                                                    &expected,
+                                                    desired,
+                                                    memory_order_acq_rel,
+                                                    memory_order_acquire);
+        if (succ) {
+            return true;
+        } else if (rw_counter(n) == rw_counter(expected)) {
+            /* We ignore the waiters when upgrading a lock. So if we
+             * failed, but the counters remained the same, then only
+             * the waiter field changed. We retry with the new waiter. */
+            n = expected;
+            continue;
+        } else {
+            return false;
+        }
     } while (true);
 }
 
@@ -75,20 +291,12 @@ void
 picotm_rwlock_try_wrlock(struct picotm_rwlock* self, bool upgrade,
                          struct picotm_error* error)
 {
-    assert(self);
+    static const bool (*try_lock[])(struct picotm_rwlock*) = {
+        try_wrlock,
+        try_uplock
+    };
 
-    /* Expect us to be the only reader if we're upgrading, otherwise expect
-     * us to be the only transaction at all. */
-    uint8_t expected = upgrade ? 1 : 0;
-
-    bool succ = atomic_compare_exchange_strong_explicit(&self->n,
-                                                        &expected, UINT8_MAX,
-                                                        memory_order_relaxed,
-                                                        memory_order_relaxed);
-    if (!succ) {
-        picotm_error_set_conflicting(error, self);
-        return;
-    }
+    try_lock_or_wait(self, try_lock[upgrade], error);
 }
 
 PICOTM_EXPORT
@@ -97,16 +305,129 @@ picotm_rwlock_unlock(struct picotm_rwlock* self)
 {
     assert(self);
 
-    uint8_t n = atomic_load_explicit(&self->n, memory_order_relaxed);
+    uint8_t n = atomic_load_explicit(&self->n, memory_order_acquire);
 
-    if (n == UINT8_MAX) {
+    assert(rw_counter(n) != 0);
+
+    if (rw_counter(n) == WRITER_COUNTER) {
+
         /* We're a writer; set counter to zero. */
-        atomic_store_explicit(&self->n, 0, memory_order_relaxed);
-        return;
+        //atomic_store_explicit(&self->n, 0, memory_order_release);
+        assert(rw_counter(n) == WRITER_COUNTER);
+        atomic_fetch_sub_explicit(&self->n, WRITER_COUNTER, memory_order_acq_rel);
+
+    } else {
+
+        /* We're a reader; decrement counter. */
+        assert(rw_counter(n) != WRITER_COUNTER);
+        atomic_fetch_sub_explicit(&self->n, 1, memory_order_acq_rel);
     }
 
-    assert(n != 0);
+    if (rw_index(n)) {
 
-    /* We're a reader; decrement counter. */
-    atomic_fetch_sub_explicit(&self->n, 1, memory_order_relaxed);
+        uint8_t n = atomic_load_explicit(&self->n, memory_order_acquire);
+
+        /* We've released the lock at this point. Waiters can now
+         * be woken up. */
+
+        struct picotm_lock_owner* waiter =
+            picotm_lock_owner_get_thread_local_instance();
+
+        struct picotm_lock_manager* lm =
+            picotm_lock_owner_get_lock_manager(waiter);
+
+        do {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_lock_manager_wake_up(lm, true,
+                                        &s_picotm_rwlock_slist_funcs, self,
+                                        &error);
+            if (picotm_error_is_set(&error)) {
+                picotm_error_mark_as_non_recoverable(&error);
+                picotm_recover_from_error(&error);
+                continue;
+            }
+            break;
+        } while (true);
+    }
+}
+
+unsigned long
+picotm_rwlock_set_index(struct picotm_rwlock* self,
+                        unsigned long desired_index)
+{
+    unsigned long expected_index = picotm_rwlock_get_index(self);
+
+    do {
+        unsigned long current_index =
+            picotm_rwlock_cmpxchg_index(self, expected_index, desired_index);
+
+        if (current_index == expected_index) {
+            return current_index;
+        }
+
+        expected_index = current_index;
+
+    } while (true);
+}
+
+unsigned long
+picotm_rwlock_get_index(struct picotm_rwlock* self)
+{
+    assert(self);
+
+    uint8_t n = atomic_load_explicit(&self->n, memory_order_acquire);
+
+    return rw_index(n);
+}
+
+unsigned long
+picotm_rwlock_cmpxchg_index(struct picotm_rwlock* self,
+                            unsigned long expected_index,
+                            unsigned long desired_index)
+{
+    assert(self);
+
+    uint8_t n = atomic_load_explicit(&self->n, memory_order_acquire);
+
+    do {
+        /* Test and ... */
+
+        uint8_t current_index = rw_index(n);
+        if (current_index != expected_index) {
+            return current_index;
+        }
+
+        /* ... Test-And-Set. */
+
+        uint8_t expected = rw_counter_bits(rw_counter(n)) |
+                           rw_index_bits(expected_index);
+
+        uint8_t desired = rw_counter_bits(rw_counter(n)) |
+                          rw_index_bits(desired_index);
+
+        bool succ =
+            atomic_compare_exchange_strong_explicit(&self->n,
+                                                    &expected,
+                                                    desired,
+                                                    memory_order_acq_rel,
+                                                    memory_order_acquire);
+        if (succ) {
+
+            /* Success */
+            return rw_index(expected);
+
+        } else if (rw_index(expected) != rw_index(n)) {
+
+            /* 'Expected' now contains the then-current waiter
+             * index. We return it for the caller to compare. */
+            return rw_index(expected);
+
+        } else {
+
+            /* Only the counter changed meanwhile; we try again
+             * re-using the value of 'expected'. */
+            n = expected;
+            continue;
+        }
+    } while (true);
 }

--- a/src/picotm-lib-rwlock.h
+++ b/src/picotm-lib-rwlock.h
@@ -1,0 +1,45 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "picotm/picotm-lib-rwlock.h"
+
+/**
+ * \cond impl || lib_impl
+ * \ingroup lib_impl
+ * \file
+ * \endcond
+ */
+
+/*
+ * Internal R/W lock interface
+ */
+
+unsigned long
+picotm_rwlock_set_index(struct picotm_rwlock* self,
+                        unsigned long desired_index);
+
+unsigned long
+picotm_rwlock_get_index(struct picotm_rwlock* self);
+
+unsigned long
+picotm_rwlock_cmpxchg_index(struct picotm_rwlock* self,
+                            unsigned long expected_index,
+                            unsigned long desired_index);

--- a/src/picotm_lock_manager.c
+++ b/src/picotm_lock_manager.c
@@ -1,0 +1,691 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "picotm_lock_manager.h"
+#include <assert.h>
+#include <search.h>
+#include <string.h>
+#include "picotm_lock_owner.h"
+#include "picotm_os_timespec.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-module.h"
+#include "table.h"
+
+void
+picotm_lock_manager_init(struct picotm_lock_manager* self,
+                         struct picotm_error* error)
+{
+    assert(self);
+
+    picotm_os_rwlock_init(&self->lo_rwlock, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+
+    self->lo = NULL;
+    self->nlos = 0;
+}
+
+void
+picotm_lock_manager_uninit(struct picotm_lock_manager* self)
+{
+    assert(self);
+
+    tabfree(self->lo);
+
+    picotm_os_rwlock_uninit(&self->lo_rwlock);
+}
+
+/*
+ * Requires writer lock on lock_manager::lo_rwlock
+ */
+static void
+grow_lo_array(struct picotm_lock_manager* self, struct picotm_error* error)
+{
+    assert(self);
+
+    /* Allocate an additional first element if array is still
+     * empty. Index 0 is a magic value and never handed out to
+     * lock owners. */
+    size_t new_nlos = !(self->nlos) + self->nlos + 1;
+
+    struct picotm_lock_owner** new_lo = tabresize(self->lo, self->nlos,
+                                                  new_nlos, sizeof(self->lo),
+                                                  error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+
+    struct picotm_lock_owner** beg = picotm_arrayat(new_lo, self->nlos);
+    struct picotm_lock_owner* const * end = picotm_arrayat(new_lo, new_nlos);
+
+    while (beg < end) {
+        *beg = NULL;
+        ++beg;
+    }
+
+    self->lo = new_lo;
+    self->nlos = new_nlos;
+}
+
+static int
+ptrcmp(const void* key, const void* instance)
+{
+    const void* lhs = *((const void* const *)key);
+    const void* rhs = *((const void* const *)instance);
+
+    return (lhs > rhs) - (lhs < rhs);
+}
+
+/*
+ * Requires writer lock on lock_manager::lo_rwlock
+ *
+ * The find_lo() function always skips the first element of
+ * |self->lo|. The index of 0 is a magic value, so we don't
+ * hand it out to lock owners.
+ */
+static struct picotm_lock_owner**
+find_lo(struct picotm_lock_manager* self, struct picotm_lock_owner* lo,
+        struct picotm_error* error)
+{
+    static const struct picotm_lock_owner* key = NULL;
+    size_t nlos = self->nlos - !!(self->nlos);
+
+    struct picotm_lock_owner** pos = lfind(&key, self->lo + (!!nlos), &nlos,
+                                           sizeof(*self->lo), ptrcmp);
+    if (pos) {
+        return pos;
+    }
+
+    nlos = self->nlos;
+
+    grow_lo_array(self, error);
+    if (picotm_error_is_set(error)) {
+        return NULL;
+    }
+
+    pos = self->lo + (!nlos) + nlos;
+    assert(pos != self->lo);
+    assert(!(*pos));
+
+    return pos;
+}
+
+void
+picotm_lock_manager_register_owner(struct picotm_lock_manager* self,
+                                   struct picotm_lock_owner* lo,
+                                   struct picotm_error* error)
+{
+    assert(self);
+    assert(lo);
+
+    picotm_os_rwlock_wrlock(&self->lo_rwlock, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+
+    struct picotm_lock_owner** pos = find_lo(self, NULL, error);
+    if (picotm_error_is_set(error)) {
+        goto err_find_lo;
+    }
+
+    assert(!(*pos));
+    *pos = lo;
+    picotm_lock_owner_set_index(lo, pos - self->lo);
+
+    picotm_os_rwlock_unlock(&self->lo_rwlock);
+
+    return;
+
+err_find_lo:
+    picotm_os_rwlock_unlock(&self->lo_rwlock);
+}
+
+void
+picotm_lock_manager_unregister_owner(struct picotm_lock_manager* self,
+                                     struct picotm_lock_owner* lo)
+{
+    assert(self);
+
+    do {
+        struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+        picotm_os_rwlock_wrlock(&self->lo_rwlock, &error);
+        if (picotm_error_is_set(&error)) {
+            picotm_error_mark_as_non_recoverable(&error);;
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+
+    self->lo[picotm_lock_owner_get_index(lo)] = NULL;
+
+    picotm_os_rwlock_unlock(&self->lo_rwlock);
+}
+
+/*
+ * Listing Handling
+ */
+
+static void
+lock_and_prepend_waiter(struct picotm_lock_manager* self,
+                        struct picotm_lock_owner* waiter,
+                        const struct picotm_lock_slist_funcs* slist_funcs,
+                        void* slist, struct picotm_error* error)
+{
+    picotm_os_rwlock_rdlock(&self->lo_rwlock, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+
+    picotm_lock_owner_lock(waiter, error);
+    if (picotm_error_is_set(error)) {
+        goto err_picotm_lock_owner_lock;
+    }
+
+    unsigned long index = picotm_lock_owner_get_index(waiter);
+
+    unsigned long first_index = slist_funcs->get_first_index(slist);
+    struct picotm_lock_owner* first_waiter = NULL;
+
+    do {
+
+        /* We retrieve the instance of the current first entry in the
+         * waiter list. */
+        assert(first_index < self->nlos);
+        first_waiter = self->lo[first_index];
+
+        /* At this point we have the index and instance of the first waiter
+         * in the list. The list and the first waiter itself is not locked,
+         * so a new first waiter can appear any time. We handle this case
+         * below in a separate test.
+         */
+
+        /* update waiter to refer to current first element. */
+        picotm_lock_owner_set_next(waiter, first_index);
+        waiter->next = first_waiter;
+
+        unsigned long old_first_index =
+            slist_funcs->cmpxchg_first_index(slist, first_index, index);
+
+        /* The first list element has not changed if the list's
+         * first index is still the index we retrieved before. A
+         * new element might have been prepended meanwhile to the
+         * list. In this case we drop our first element and start
+         * anew.
+         */
+
+        if (old_first_index != first_index) {
+            /* The first list element changed, so we do the look-up
+             * again. */
+            first_index = old_first_index;
+            first_waiter = NULL;
+            continue;
+        }
+        break;
+    } while (true);
+
+    picotm_os_rwlock_unlock(&self->lo_rwlock);
+
+    return;
+
+err_picotm_lock_owner_lock:
+    picotm_os_rwlock_unlock(&self->lo_rwlock);
+}
+
+static struct picotm_lock_owner*
+get_first_waiter(struct picotm_lock_manager* self,
+                 const struct picotm_lock_slist_funcs* slist_funcs,
+                 void* slist, struct picotm_error* error)
+{
+    struct picotm_lock_owner* first_waiter = NULL;
+
+    unsigned long first_index = slist_funcs->get_first_index(slist);
+
+    /* We retrieve the index and locked instance of the current
+     * first entry in the waiter list. The waiter can disappear
+     * between looking up the index and the locked instance. In
+     * this case, we start again with an updated index.
+     */
+
+    while (first_index && !first_waiter) {
+
+        assert(first_index < self->nlos);
+        first_waiter = self->lo[first_index];
+
+        picotm_lock_owner_lock(first_waiter, error);
+        if (picotm_error_is_set(error)) {
+            return NULL;
+        }
+
+        first_index = slist_funcs->get_first_index(slist);
+
+        if (!first_waiter) {
+            /* The first waiter disappeared after retrieving the
+             * index. */
+            continue;
+        } else if (picotm_lock_owner_get_index(first_waiter) != first_index) {
+            /* The first list element changed, so we do the look-up
+             * again. */
+            picotm_lock_owner_unlock(first_waiter);
+            first_waiter = NULL;
+            continue;
+        }
+    }
+
+    return first_waiter;
+}
+
+static struct picotm_lock_owner*
+find_prec_waiter(struct picotm_lock_manager* self,
+                 struct picotm_lock_owner* waiter,
+                 struct picotm_lock_owner* first_waiter,
+                 const struct picotm_lock_slist_funcs* slist_funcs,
+                 void* slist, struct picotm_error* error)
+{
+    assert(first_waiter || !waiter);
+
+    if (first_waiter == waiter) {
+        return NULL; /* no previous list element */
+    }
+
+    struct picotm_lock_owner* prec_waiter = NULL;
+
+    while (first_waiter->next) {
+
+        struct picotm_lock_owner* next_waiter = first_waiter->next;
+
+        if (next_waiter == waiter) {
+            prec_waiter = first_waiter;
+            goto out;
+        }
+        picotm_lock_owner_lock(next_waiter, error);
+        if (picotm_error_is_set(error)) {
+            picotm_lock_owner_unlock(first_waiter);
+            goto out;
+        }
+        picotm_lock_owner_unlock(first_waiter);
+        first_waiter = next_waiter;
+    }
+
+    /* We must have stopped before reaching 'waiter'. */
+    assert(false);
+
+out:
+    assert(!prec_waiter || (prec_waiter->next == waiter));
+
+    do {
+        struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+        picotm_lock_owner_lock(prec_waiter->next, &error);
+        if (picotm_error_is_set(&error)) {
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+
+    return prec_waiter;
+}
+
+/* Removes a waiter from a lock's waiting list. The 'waiter' and
+ * 'prec_waiter' have to be locked. The 'prec_waiter' is optional.
+ *
+ * The function might change the 'prec_waiter' and acquire a lock
+ * on the new instance. The locked 'prec_waiter' is returned and
+ * it's the callers responsibility to unlock.
+ */
+static struct picotm_lock_owner*
+remove_waiter(struct picotm_lock_manager* self,
+              struct picotm_lock_owner* waiter,
+              struct picotm_lock_owner* prec_waiter,
+              const struct picotm_lock_slist_funcs* slist_funcs, void* slist)
+{
+    do {
+        struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+        picotm_os_rwlock_rdlock(&self->lo_rwlock, &error);
+        if (picotm_error_is_set(&error)) {
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+
+    do {
+        if (!prec_waiter) {
+
+            /* No (known) preceding waiter in the list. We try to remove
+             * the waiter directly from the lock's list header.
+             */
+
+            unsigned long index = picotm_lock_owner_get_index(waiter);
+            unsigned long next_index = picotm_lock_owner_get_next(waiter);
+
+            unsigned long old_first_index =
+                slist_funcs->cmpxchg_first_index(slist, index, next_index);
+
+            if (old_first_index == index) {
+                unsigned long current = slist_funcs->get_first_index(slist);
+                goto out; /* removed waiter from lock; early out */
+            }
+
+        } else if (prec_waiter->next == waiter) {
+
+            /* We have a preceding waiter that is still up-to-date.
+             */
+
+            unsigned long next_index = picotm_lock_owner_get_next(waiter);
+            picotm_lock_owner_set_next(prec_waiter, next_index);
+            prec_waiter->next = waiter->next;
+
+            goto out; /* removed waiter from list; early out */
+
+        } else {
+
+            /* Unlisting fails if the preceding waiter changed meanwhile. In
+             * this case, we unlock the current preceding waiter and search for
+             * the current one.
+             */
+
+            picotm_lock_owner_unlock(prec_waiter);
+        }
+
+        /* To preserve the waiter list's locking order, we have to
+         * unlock the waiter *before* calling get_first_waiter(). The
+         * lock will be re-acquired by find_prec_waiter(). */
+        picotm_lock_owner_unlock(waiter);
+
+        struct picotm_lock_owner* first_waiter = NULL;
+
+        do {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            first_waiter = get_first_waiter(self, slist_funcs, slist,
+                                            &error);
+            if (picotm_error_is_set(&error)) {
+                picotm_error_mark_as_non_recoverable(&error);
+                picotm_recover_from_error(&error);
+                continue;
+            }
+            break;
+        } while (true);
+
+        assert(first_waiter);
+
+        do {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            prec_waiter = find_prec_waiter(self, waiter, first_waiter,
+                                           slist_funcs, slist, &error);
+            if (picotm_error_is_set(&error)) {
+                picotm_error_mark_as_non_recoverable(&error);
+                picotm_recover_from_error(&error);
+                continue;
+            }
+            break;
+        } while (true);
+
+    } while (true);
+
+out:
+    picotm_os_rwlock_unlock(&self->lo_rwlock);
+
+    return prec_waiter;
+}
+
+/*
+ * Waiting
+ */
+
+/* waits for another duration of the waiter transaction */
+static void
+compute_timeout(struct picotm_lock_owner* waiter, struct timespec* timeout,
+                struct picotm_error* error)
+{
+    picotm_os_get_timespec(timeout, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+
+    struct timespec timediff;
+    timediff.tv_sec = 0;
+    timediff.tv_nsec = 1000;
+    picotm_os_add_timespec(timeout, &timediff);
+}
+
+bool
+picotm_lock_manager_wait(struct picotm_lock_manager* self,
+                         struct picotm_lock_owner* waiter, bool wr,
+                         const struct picotm_lock_slist_funcs* slist_funcs,
+                         void* slist, struct picotm_error* error)
+{
+    /* On success, we will have acquired a lock on 'waiter'. */
+    lock_and_prepend_waiter(self, waiter, slist_funcs, slist, error);
+    if (picotm_error_is_set(error)) {
+        return false;
+    }
+
+    waiter->flags |= wr ? LOCK_OWNER_WR : LOCK_OWNER_RD;
+
+    struct timespec timeout;
+    compute_timeout(waiter, &timeout, error);
+    if (picotm_error_is_set(error)) {
+        goto err_compute_timeout;
+    }
+
+    bool woken_up = picotm_lock_owner_wait_until(waiter, &timeout, error);
+    if (picotm_error_is_set(error)) {
+        goto err_picotm_lock_owner_locked_wait;
+    }
+
+    struct picotm_lock_owner* prec_waiter = remove_waiter(self, waiter, NULL,
+                                                          slist_funcs, slist);
+    if (prec_waiter) {
+        picotm_lock_owner_unlock(prec_waiter);
+    }
+
+    waiter->flags &= (wr ? ~LOCK_OWNER_WR : ~LOCK_OWNER_RD);
+
+    picotm_lock_owner_unlock(waiter);
+
+    return woken_up;
+
+err_picotm_lock_owner_locked_wait:
+    prec_waiter = remove_waiter(self, waiter, NULL, slist_funcs, slist);
+    if (prec_waiter) {
+        picotm_lock_owner_unlock(prec_waiter);
+    }
+err_compute_timeout:
+    waiter->flags &= (wr ? ~LOCK_OWNER_WR : ~LOCK_OWNER_RD);
+    picotm_lock_owner_unlock(waiter);
+    return false;
+}
+
+/*
+ * Wake up
+ */
+
+/**
+ * This is the function that decides about which lock owner to schedule
+ * next for a lock. Reimplement with different strategies if necessary.
+ *
+ * When entering this function, 'first_waiter' has to be locked
+ * already. Except for 'first_waiter' and the returned lock owner,
+ * all lock owners are expected to be *unlocked* after this
+ * function returned.
+ */
+static struct picotm_lock_owner*
+pick_longest_waiting(struct picotm_lock_owner* first_waiter,
+                     struct picotm_error* error)
+{
+    /* pick longest waiting */
+
+    struct picotm_lock_owner* picked_waiter = NULL;
+
+    struct picotm_lock_owner* waiter = first_waiter;
+
+    while (waiter) {
+
+        if (waiter->flags & LOCK_OWNER_WT) {
+            if (picked_waiter && (picked_waiter != first_waiter)) {
+                picotm_lock_owner_unlock(picked_waiter);
+            }
+            picked_waiter = waiter;
+        }
+
+        struct picotm_lock_owner* next_waiter = waiter->next;
+
+        if (next_waiter) {
+
+            picotm_lock_owner_lock(next_waiter, error);
+            if (picotm_error_is_set(error)) {
+                if (waiter != first_waiter) {
+                    picotm_lock_owner_unlock(waiter);
+                }
+                if (picked_waiter
+                        && (picked_waiter != first_waiter)
+                        && (picked_waiter != waiter)) {
+                    picotm_lock_owner_unlock(picked_waiter);
+                }
+                return NULL;
+            }
+        }
+
+        if ((waiter != picked_waiter) && (waiter != first_waiter)) {
+            picotm_lock_owner_unlock(waiter);
+        }
+
+        waiter = next_waiter;
+    }
+
+    return picked_waiter;
+}
+
+void
+picotm_lock_manager_wake_up(struct picotm_lock_manager* self,
+                            bool concurrent_readers_supported,
+                            const struct picotm_lock_slist_funcs* slist_funcs,
+                            void* slist, struct picotm_error* error)
+{
+    assert(self);
+
+    picotm_os_rwlock_rdlock(&self->lo_rwlock, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+
+    struct picotm_lock_owner* first_waiter =
+        get_first_waiter(self, slist_funcs, slist, error);
+    if (picotm_error_is_set(error)) {
+        goto err_get_first_waiter;
+    }
+
+    if (!first_waiter) {
+        /* That's not really an error; maybe the lock's list
+         * has been emptied by other threads. */
+        goto out;
+    }
+
+    struct picotm_lock_owner* picked_waiter =
+        pick_longest_waiting(first_waiter, error);
+    if (picotm_error_is_set(error)) {
+        goto err_pick_next;
+    }
+
+    if (!picked_waiter) {
+        /* Again, that's not really an error. */
+        picotm_lock_owner_unlock(first_waiter);
+        goto out;
+    }
+
+    assert(picked_waiter->flags & (LOCK_OWNER_RD | LOCK_OWNER_WR));
+
+    /* Wake up selected waiter */
+
+    picotm_lock_owner_wake_up(picked_waiter, error);
+    if (picotm_error_is_set(error)) {
+        goto err_picotm_lock_owner_wake_up;
+    }
+
+    bool wake_up_all_readers =
+        concurrent_readers_supported
+            && (picked_waiter->flags & LOCK_OWNER_RD);
+
+    if (picked_waiter != first_waiter) {
+        picotm_lock_owner_unlock(picked_waiter);
+    }
+
+    if (wake_up_all_readers) {
+
+        /* Wake up all readers if a reader was selected. */
+
+        struct picotm_lock_owner* waiter = first_waiter;
+        struct picotm_lock_owner* prec_waiter = NULL;
+
+        while (waiter) {
+
+            /* During this loop we always hold a lock on the current and
+             * the previous value of 'waiter'. The initial value of 'waiter'
+             * has already been locked when we enter the loop. Further
+             * locking is ordered by the item's list position. Deadlocks
+             * with concurrent transaction are therefore impossible.
+             */
+
+            if ((waiter->flags & LOCK_OWNER_RD)
+                    && (waiter->flags & LOCK_OWNER_WT)) {
+                picotm_lock_owner_wake_up(waiter, error);
+                if (picotm_error_is_set(error)) {
+                    if (prec_waiter) {
+                        picotm_lock_owner_unlock(prec_waiter);
+                    }
+                    picotm_lock_owner_unlock(waiter);
+                    picotm_os_rwlock_unlock(&self->lo_rwlock);
+                    return;
+                }
+            }
+
+            prec_waiter = waiter;
+            waiter = waiter->next;
+
+            if (waiter) {
+                picotm_lock_owner_lock(waiter, error);
+                if (picotm_error_is_set(error)) {
+                    picotm_lock_owner_unlock(prec_waiter);
+                    picotm_os_rwlock_unlock(&self->lo_rwlock);
+                    return;
+                }
+            }
+            picotm_lock_owner_unlock(prec_waiter);
+        }
+    } else {
+        picotm_lock_owner_unlock(first_waiter);
+    }
+
+out:
+    picotm_os_rwlock_unlock(&self->lo_rwlock);
+
+    return;
+
+err_picotm_lock_owner_wake_up:
+    picotm_lock_owner_unlock(picked_waiter);
+err_pick_next:
+    picotm_lock_owner_unlock(first_waiter);
+err_get_first_waiter:
+    picotm_os_rwlock_unlock(&self->lo_rwlock);
+}

--- a/src/picotm_lock_manager.h
+++ b/src/picotm_lock_manager.h
@@ -1,0 +1,140 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "picotm_os_rwlock.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * \cond impl || lib_impl
+ * \ingroup lib_impl
+ * \file
+ * \endcond
+ */
+
+struct picotm_error;
+struct picotm_lock_owner;
+
+/**
+ * \brief Contains call-back functions for lock implementations.
+ */
+struct picotm_lock_slist_funcs {
+
+    unsigned long (*get_first_index)(void*);
+
+    unsigned long (*cmpxchg_first_index)(void*, unsigned long, unsigned long);
+};
+
+/**
+ * \brief Coordinates among lock owners contending for locks.
+ */
+struct picotm_lock_manager {
+
+    struct picotm_os_rwlock    lo_rwlock;
+    struct picotm_lock_owner** lo;
+    size_t                     nlos;
+};
+
+/**
+ * \brief Initializes a lock-manager instance.
+ * \param self The lock manager.
+ * \param [out] error Returns an error to the caller.
+ */
+void
+picotm_lock_manager_init(struct picotm_lock_manager* self,
+                         struct picotm_error* error);
+
+/**
+ * \brief Cleans-up a lock-manager instance.
+ * \param self The lock manager.
+ */
+void
+picotm_lock_manager_uninit(struct picotm_lock_manager* self);
+
+/**
+ * \brief Registers a lock owner at a lock manager.
+ * \param self The lock manager.
+ * \param lo The lock owner.
+ * \param [out] error Returns an error to the caller.
+ *
+ * Each lock-owner instance has to be registered at the lock manager
+ * exactly once. This function assigns an index to the lock owner, so
+ * it can be queued up in a waiter list.
+ */
+void
+picotm_lock_manager_register_owner(struct picotm_lock_manager* self,
+                                   struct picotm_lock_owner* lo,
+                                   struct picotm_error* error);
+
+/**
+ * \brief Unregisters a lock owner at a lock manager.
+ * \param self The lock manager.
+ * \param lo The lock owner.
+ *
+ * Lock owner have to be unregistered at their lock manager before
+ * cleaning them up. After this function returns, the lock owner's
+ * index will be available for registration.
+ */
+void
+picotm_lock_manager_unregister_owner(struct picotm_lock_manager* self,
+                                     struct picotm_lock_owner* lo);
+
+/**
+ * \brief Instructs a lock manager to setup a lock owner for waiting.
+ * \param self The lock manager.
+ * \param lo The lock owner.
+ * \param is_writer The lock owner is waiting to acquire a writer lock.
+ * \param slist_funcs The lock list's call-back functions.
+ * \param slist The anonymous lock-list data structure.
+ * \param [out] error Returns an error to the caller.
+ */
+bool
+picotm_lock_manager_wait(struct picotm_lock_manager* self,
+                         struct picotm_lock_owner* lo, bool is_writer,
+                         const struct picotm_lock_slist_funcs* slist_funcs,
+                         void* slist, struct picotm_error* error);
+
+/**
+ * \brief Instructs a lock manager to wake up one or more waiting lock owners.
+ * \param self The lock manager.
+ * \param concurrent_readers_supported True if the lock can support multiple
+ *                                     concurrent readers.
+ * \param slist_funcs The lock list's call-back functions.
+ * \param slist The anonymous lock-list data structure.
+ * \param [out] error Returns an error to the caller.
+ */
+void
+picotm_lock_manager_wake_up(struct picotm_lock_manager* self,
+                            bool concurrent_readers_supported,
+                            const struct picotm_lock_slist_funcs* slist_funcs,
+                            void* slist, struct picotm_error* error);
+
+/*
+ * Look-up functions.
+ */
+
+/**
+ * \brief Returns the lock manager of a lock owner.
+ * \param lown A lock-owner instance.
+ * \returns The lock owner's lock manager.
+ */
+struct picotm_lock_manager*
+picotm_lock_owner_get_lock_manager(struct picotm_lock_owner* lown);

--- a/src/picotm_lock_owner.c
+++ b/src/picotm_lock_owner.c
@@ -1,0 +1,189 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "picotm_lock_owner.h"
+#include <assert.h>
+#include "picotm_os_timespec.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-module.h"
+
+void
+picotm_lock_owner_init(struct picotm_lock_owner* self,
+                       struct picotm_error* error)
+{
+    assert(self);
+
+    picotm_os_mutex_init(&self->mutex, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+
+    picotm_os_cond_init(&self->wait_cond, error);
+    if (picotm_error_is_set(error)) {
+        goto err_picotm_os_cond_init;
+    }
+
+    self->flags = 0;
+    self->next = NULL;
+
+    return;
+
+err_picotm_os_cond_init:
+    picotm_os_mutex_uninit(&self->mutex);
+}
+
+void
+picotm_lock_owner_uninit(struct picotm_lock_owner* self)
+{
+    assert(self);
+
+    picotm_os_mutex_uninit(&self->mutex);
+    picotm_os_cond_uninit(&self->wait_cond);
+}
+
+void
+picotm_lock_owner_set_index(struct picotm_lock_owner* self,
+                            unsigned long index)
+{
+    assert(self);
+    assert(index < (1ul << 10));
+
+    self->flags = (self->flags & ~0x3ff) | (index & 0x3ff);
+}
+
+unsigned long
+picotm_lock_owner_get_index(const struct picotm_lock_owner* self)
+{
+    assert(self);
+
+    return self->flags & 0x3ff;
+}
+
+void
+picotm_lock_owner_set_next(struct picotm_lock_owner* self,
+                           unsigned long next)
+{
+    assert(self);
+    assert(next < (1ul << 10));
+
+    self->flags = (self->flags & ~0xffc00) | ((next & 0x3ff) << 10);
+}
+
+unsigned long
+picotm_lock_owner_get_next(const struct picotm_lock_owner* self)
+{
+    assert(self);
+
+    return (self->flags >> 10) & 0x3ff;
+}
+
+const struct timespec*
+picotm_lock_owner_get_timestamp(const struct picotm_lock_owner* self)
+{
+    assert(self);
+
+    return &self->timestamp;
+}
+
+void
+picotm_lock_owner_reset_timestamp(struct picotm_lock_owner* self,
+                                  struct picotm_error* error)
+{
+    assert(self);
+
+    picotm_os_get_timespec(&self->timestamp, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+}
+
+void
+picotm_lock_owner_lock(struct picotm_lock_owner* self,
+                       struct picotm_error* error)
+{
+    assert(self);
+
+    picotm_os_mutex_lock(&self->mutex, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+}
+
+void
+picotm_lock_owner_unlock(struct picotm_lock_owner* self)
+{
+    assert(self);
+
+    picotm_os_mutex_unlock(&self->mutex);
+}
+
+bool
+picotm_lock_owner_wait_until(struct picotm_lock_owner* self,
+                             const struct timespec* timeout,
+                             struct picotm_error* error)
+{
+    assert(self);
+    assert(!(self->flags & LOCK_OWNER_WT));
+
+    /* set waiting flag */
+    self->flags |= LOCK_OWNER_WT;
+
+    bool woken_up;
+
+    do {
+        woken_up = picotm_os_cond_wait_until(&self->wait_cond,
+                                             &self->mutex,
+                                             timeout, error);
+        if (picotm_error_is_set(error)) {
+            goto err_picotm_os_cond_wait_until;
+        }
+
+        /* Platforms can have spurious wake-ups from condition
+         * variables. The presence of the waiting flag signals
+         * a spurious wakeup. */
+    } while (woken_up && (self->flags & LOCK_OWNER_WT));
+
+    if (!woken_up) {
+        /* clear waiting flag */
+        self->flags &= ~LOCK_OWNER_WT;
+    }
+
+    return woken_up;
+
+err_picotm_os_cond_wait_until:
+    /* clear waiting flag */
+    self->flags &= ~LOCK_OWNER_WT;
+    return false;
+}
+
+void
+picotm_lock_owner_wake_up(struct picotm_lock_owner* self,
+                          struct picotm_error* error)
+{
+    assert(self);
+    assert(self->flags & LOCK_OWNER_WT);
+
+    /* clear waiting flag */
+    self->flags &= ~LOCK_OWNER_WT;
+
+    picotm_os_cond_wake_up(&self->wait_cond, error);
+    if (picotm_error_is_set(error)) {
+        return;
+    }
+}

--- a/src/picotm_lock_owner.h
+++ b/src/picotm_lock_owner.h
@@ -1,0 +1,207 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <time.h>
+#include "picotm_os_cond.h"
+#include "picotm_os_mutex.h"
+
+/**
+ * \cond impl || lib_impl
+ * \ingroup lib_impl
+ * \file
+ * \endcond
+ */
+
+struct picotm_error;
+
+/**
+ * \brief Lock-owner state flags.
+ */
+enum picotm_picotm_lock_owner_flags {
+    /** \brief Lock owner is waiting */
+    LOCK_OWNER_WT = 1ul << 29,
+    /** \brief Lock owner is waiting to acquire a reader lock */
+    LOCK_OWNER_RD = 1ul << 30,
+    /** \brief Lock owner is waiting to acquire a writer lock*/
+    LOCK_OWNER_WR = 1ul << 31
+};
+
+/**
+ * \brief Represents the potential owner of a lock.
+ */
+struct picotm_lock_owner {
+
+    /**
+     * \brief Encodes information about the owner of a lock.
+     *
+     * | 31 | 30 | 29 | 19    ...     10 | 9 .. 0 |
+     * | WR | RD | WT |     <empty>      | index  |
+     */
+    unsigned long flags;
+
+    /** Entry in waiter list */
+    struct picotm_lock_owner* next;
+
+    /** Start time of the lock owner's transaction*/
+    struct timespec timestamp;
+
+    struct picotm_os_cond  wait_cond;
+    struct picotm_os_mutex mutex;
+};
+
+/**
+ * \brief Initializes a lock-owner instance.
+ * \param self The lock owner to initialize.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_lock_owner_init(struct picotm_lock_owner* self,
+                       struct picotm_error* error);
+
+/**
+ * \brief Cleans up a lock-owner instance.
+ * \param self The lock owner to clean up.
+ */
+void
+picotm_lock_owner_uninit(struct picotm_lock_owner* self);
+
+/**
+ * \brief Sets the index of the next list element after a lock owner.
+ * \param self The lock owner.
+ * \param index The index of the next list element after the lock owner.
+ */
+void
+picotm_lock_owner_set_index(struct picotm_lock_owner* self,
+                            unsigned long index);
+
+/**
+ * \brief Returns a lock owner's index.
+ * \param self The lock owner.
+ * \returns The lock owner's index.
+ */
+unsigned long
+picotm_lock_owner_get_index(const struct picotm_lock_owner* self);
+
+/**
+ * \brief Sets the index of the next list element after a lock owner.
+ * \param self The lock owner.
+ * \param next The index of the next list element after the lock owner.
+ */
+void
+picotm_lock_owner_set_next(struct picotm_lock_owner* self,
+                           unsigned long next);
+
+/**
+ * \brief Returns the index of the next list element after a lock owner.
+ * \param self The lock owner.
+ * \returns The index of the next list element after the lock owner.
+ */
+unsigned long
+picotm_lock_owner_get_next(const struct picotm_lock_owner* self);
+
+/**
+ * \brief Resets a lock owner's timestamp.
+ * \param self The lock owner.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_lock_owner_reset_timestamp(struct picotm_lock_owner* self,
+                                  struct picotm_error* error);
+
+/**
+ * \brief Returns a lock owner's timestamp.
+ * \param self The lock owner.
+ * \returns The timestamp of the lock owner.
+ */
+const struct timespec*
+picotm_lock_owner_get_timestamp(const struct picotm_lock_owner* self);
+
+/**
+ * \brief Acquires an exclusive lock on a lock owner.
+ * \param self The lock owner.
+ * \param[out] Returns an error to the caller.
+ *
+ * After successfully acquiring a lock on a lock owner, the caller is
+ * responsible to release the lock afterwards with a call to
+ * `picotm_lock_owner_unlock()`.
+ */
+void
+picotm_lock_owner_lock(struct picotm_lock_owner* self,
+                       struct picotm_error* error);
+
+/**
+ * \brief Releases a lock on a lock owner.
+ * \param self The lock owner.
+ *
+ * Calls to this function are only allowed after acquiring a lock
+ * with `picotm_lock_owner_lock()`.
+ */
+void
+picotm_lock_owner_unlock(struct picotm_lock_owner* self);
+
+/**
+ * \brief Waits for a lock owner to be woken up, or until a timeout expires.
+ * \param self The lock owner.
+ * \param timeout The wake-up timeout.
+ * \param[out] error Returns an error to the caller.
+ * \returns True if the lock owner was woken up, or false if the timeout
+ *          expired.
+ *
+ * This function possibly sleeps and blocks the calling thread. Sleeping for
+ * and unbounded amount of time is not allowed, so the timeout must contain
+ * some absolute point of time in the future.
+ *
+ * Callers of this function are required to successfully acquire the lock
+ * on the lock owner via `picotm_lock_owner_lock()` *before* calling this
+ * function, and release the lock afterwards via `picotm_lock_owner_unlock()`.
+ * While the thread is sleeping, the lock will be unlocked.
+ *
+ * Threads should probably only wait for their own transaction's lock-owner
+ * instance. Waiting for another thread's lock owner can result in undefined
+ * behavior.
+ */
+bool
+picotm_lock_owner_wait_until(struct picotm_lock_owner* self,
+                             const struct timespec* timeout,
+                             struct picotm_error* error);
+
+/**
+ * \brief Wakes up a thread waiting for a lock owner.
+ * \param self The lock owner.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_lock_owner_wake_up(struct picotm_lock_owner* self,
+                          struct picotm_error* error);
+
+/*
+ * Look-up functions.
+ *
+ * These functions are implemented by the thread-local state handling.
+ */
+
+/**
+ * \brief Returns the local thread's lock-owner structure.
+ * \returns The thread-local lock owner.
+ */
+struct picotm_lock_owner*
+picotm_lock_owner_get_thread_local_instance(void);

--- a/src/picotm_os_cond.c
+++ b/src/picotm_os_cond.c
@@ -1,0 +1,154 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "picotm_os_cond.h"
+#include <assert.h>
+#include <errno.h>
+#include "picotm_os_mutex.h"
+#include "picotm_os_timespec.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-module.h"
+
+static void
+safe_pthread_condattr_destroy(pthread_condattr_t* attr)
+{
+    do {
+        int err = pthread_condattr_destroy(attr);
+        if (err) {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_error_set_errno(&error, err);
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+}
+
+void
+picotm_os_cond_init(struct picotm_os_cond* self, struct picotm_error* error)
+{
+    assert(self);
+
+    pthread_condattr_t attr;
+
+    int err = pthread_condattr_init(&attr);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+
+    err = pthread_condattr_setclock(&attr, PICOTM_OS_TIMESPEC_CLOCKID);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        goto err_pthread_condattr_setclock;
+    }
+
+    err = pthread_cond_init(&self->instance, &attr);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        goto err_pthread_cond_init;
+    }
+
+    safe_pthread_condattr_destroy(&attr);
+
+    return;
+
+err_pthread_cond_init:
+err_pthread_condattr_setclock:
+    safe_pthread_condattr_destroy(&attr);
+    return;
+}
+
+void
+picotm_os_cond_uninit(struct picotm_os_cond* self)
+{
+    assert(self);
+
+    do {
+        int err = pthread_cond_destroy(&self->instance);
+        if (err) {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_error_set_errno(&error, err);
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+}
+
+void
+picotm_os_cond_wait(struct picotm_os_cond* self,
+                    struct picotm_os_mutex* mutex,
+                    struct picotm_error* error)
+{
+    assert(self);
+    assert(mutex);
+
+    int err = pthread_cond_wait(&self->instance, &mutex->instance);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+}
+
+bool
+picotm_os_cond_wait_until(struct picotm_os_cond* self,
+                          struct picotm_os_mutex* mutex,
+                          const struct timespec* timeout,
+                          struct picotm_error* error)
+{
+    assert(self);
+    assert(mutex);
+
+    int err = pthread_cond_timedwait(&self->instance, &mutex->instance,
+                                     timeout);
+    if (err && (err != ETIMEDOUT)) {
+        picotm_error_set_errno(error, err);
+        return false;
+    }
+    return err != ETIMEDOUT;
+}
+
+void
+picotm_os_cond_wake_up(struct picotm_os_cond* self,
+                       struct picotm_error* error)
+{
+    assert(self);
+
+    int err = pthread_cond_signal(&self->instance);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+}
+
+void
+picotm_os_cond_wake_up_all(struct picotm_os_cond* self,
+                           struct picotm_error* error)
+{
+    assert(self);
+
+    int err = pthread_cond_broadcast(&self->instance);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+}

--- a/src/picotm_os_cond.h
+++ b/src/picotm_os_cond.h
@@ -1,0 +1,112 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <pthread.h>
+#include <stdbool.h>
+
+/**
+ * \cond impl || lib_impl
+ * \ingroup lib_impl
+ * \file
+ * \endcond
+ */
+
+struct picotm_error;
+struct picotm_os_mutex;
+struct timespec;
+
+/**
+ * \brief The condition variable of the operating system.
+ *
+ * The data structure `struct picotm_os_cond` represents a condition
+ * variable provides by the operating system. A condition variable waits
+ * for a signal while atomically releasing and acquiring a mutex lock
+ * during the process. Waiting operations are allowed to fail spuriously.
+ * An implementation of `struct picotm_os_cond` shall be able to cooperate
+ * with `struct picotm_os_mutex`.
+ */
+struct picotm_os_cond {
+    pthread_cond_t instance;
+};
+
+/**
+ * \brief Initializes a condition variable.
+ * \param self The condition variable to initialize.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_cond_init(struct picotm_os_cond* self, struct picotm_error* error);
+
+/**
+ * \brief Cleans-up a condition variable.
+ * \param self The condition variable to clean up.
+ */
+void
+picotm_os_cond_uninit(struct picotm_os_cond* self);
+
+/**
+ * \brief Waits for a wake-up signal on a condition variable.
+ * \param self The condition variable to wait at.
+ * \param mutex The mutex to release and acquire during the waiting.
+ * \param[out] error Returns an error to the caller.
+ *
+ * The mutex has to be locked by the caller before calling this function.
+ */
+void
+picotm_os_cond_wait(struct picotm_os_cond* self,
+                    struct picotm_os_mutex* mutex,
+                    struct picotm_error* error);
+
+/**
+ * \brief Waits for a wake-up signal on a condition variable until a
+ *        timeout expires.
+ * \param self The condition variable to wait at.
+ * \param mutex The mutex to release and acquire during the waiting.
+ * \param timeout The timeout for waiting.
+ * \param[out] error Returns an error to the caller.
+ * \returns True if the waiter wa swoken up by a signal, false if the
+ *          timeout has expired.
+ *
+ * The mutex has to be locked by the caller before calling this function.
+ */
+bool
+picotm_os_cond_wait_until(struct picotm_os_cond* self,
+                          struct picotm_os_mutex* mutex,
+                          const struct timespec* timeout,
+                          struct picotm_error* error);
+
+/**
+ * \brief Wakes up a single waiter of a condition variable.
+ * \param self The condition variable to wait at.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_cond_wake_up(struct picotm_os_cond* self,
+                       struct picotm_error* error);
+
+/**
+ * \brief Wakes up all waiters of a condition variable.
+ * \param self The condition variable to wait at.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_cond_wake_up_all(struct picotm_os_cond* self,
+                           struct picotm_error* error);

--- a/src/picotm_os_mutex.c
+++ b/src/picotm_os_mutex.c
@@ -1,0 +1,90 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "picotm_os_mutex.h"
+#include <assert.h>
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-module.h"
+
+void
+picotm_os_mutex_init(struct picotm_os_mutex* self, struct picotm_error* error)
+{
+    assert(self);
+
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+
+    int err = pthread_mutex_init(&self->instance, &attr);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+
+    pthread_mutexattr_destroy(&attr);
+}
+
+void
+picotm_os_mutex_uninit(struct picotm_os_mutex* self)
+{
+    assert(self);
+
+    do {
+        int err = pthread_mutex_destroy(&self->instance);
+        if (err) {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_error_set_errno(&error, err);
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+}
+
+void
+picotm_os_mutex_lock(struct picotm_os_mutex* self, struct picotm_error* error)
+{
+    assert(self);
+
+    int err = pthread_mutex_lock(&self->instance);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+}
+
+void
+picotm_os_mutex_unlock(struct picotm_os_mutex* self)
+{
+    assert(self);
+
+    do {
+        int err = pthread_mutex_unlock(&self->instance);
+        if (err) {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_error_set_errno(&error, err);
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+}

--- a/src/picotm_os_mutex.h
+++ b/src/picotm_os_mutex.h
@@ -1,0 +1,76 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <pthread.h>
+
+/**
+ * \cond impl || lib_impl
+ * \ingroup lib_impl
+ * \file
+ * \endcond
+ */
+
+struct picotm_error;
+
+/**
+ * \brief The mutex lock of the operating system.
+ *
+ * A mutex provides an exclusive lock. The data structure
+ * `struct picotm_os_mutex` is a wrapper around the mutex data
+ * structure povided by the operating system. Implementations
+ * of this structure shall be able to cooperate with instances
+ * of `struct picotm_os_cond`.
+ */
+struct picotm_os_mutex {
+    pthread_mutex_t instance;
+};
+
+/**
+ * \brief Initializes a mutex instance.
+ * \param self The mutex instance to initialize.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_mutex_init(struct picotm_os_mutex* self,
+                     struct picotm_error* error);
+
+/**
+ * \brief Cleans-up a mutex instance.
+ * \param self The mutex instance to initialize.
+ */
+void
+picotm_os_mutex_uninit(struct picotm_os_mutex* self);
+
+/**
+ * \brief Acquires a mutex lock.
+ * \param self The mutex to acquire.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_mutex_lock(struct picotm_os_mutex* self,
+                     struct picotm_error* error);
+
+/**
+ * \brief Releases a mutex lock.
+ * \param self The mutex to release.
+ */
+void
+picotm_os_mutex_unlock(struct picotm_os_mutex* self);

--- a/src/picotm_os_rwlock.c
+++ b/src/picotm_os_rwlock.c
@@ -1,0 +1,98 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "picotm_os_rwlock.h"
+#include <assert.h>
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-module.h"
+
+void
+picotm_os_rwlock_init(struct picotm_os_rwlock* self,
+                      struct picotm_error* error)
+{
+    assert(self);
+
+    int err = pthread_rwlock_init(&self->instance, NULL);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+}
+
+void
+picotm_os_rwlock_uninit(struct picotm_os_rwlock* self)
+{
+    assert(self);
+
+    do {
+        int err = pthread_rwlock_destroy(&self->instance);
+        if (err) {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_error_set_errno(&error, err);
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+}
+
+void
+picotm_os_rwlock_rdlock(struct picotm_os_rwlock* self,
+                        struct picotm_error* error)
+{
+    assert(self);
+
+    int err = pthread_rwlock_rdlock(&self->instance);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+}
+
+void
+picotm_os_rwlock_wrlock(struct picotm_os_rwlock* self,
+                        struct picotm_error* error)
+{
+    assert(self);
+
+    int err = pthread_rwlock_wrlock(&self->instance);
+    if (err) {
+        picotm_error_set_errno(error, err);
+        return;
+    }
+}
+
+void
+picotm_os_rwlock_unlock(struct picotm_os_rwlock* self)
+{
+    assert(self);
+
+    do {
+        int err = pthread_rwlock_unlock(&self->instance);
+        if (err) {
+            struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+            picotm_error_set_errno(&error, err);
+            picotm_error_mark_as_non_recoverable(&error);
+            picotm_recover_from_error(&error);
+            continue;
+        }
+        break;
+    } while (true);
+}

--- a/src/picotm_os_rwlock.h
+++ b/src/picotm_os_rwlock.h
@@ -1,0 +1,86 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <pthread.h>
+
+/**
+ * \cond impl || lib_impl
+ * \ingroup lib_impl
+ * \file
+ * \endcond
+ */
+
+struct picotm_error;
+
+/**
+ * \brief The reader/writer lock of the operating system.
+ *
+ * The data structure `struct picotm_os_rwlock` is a wrapper around
+ * the reader/writer lock provided by the operating system. R/W locks
+ * can be acquired multiple concurrent readers or a single writer. An
+ * implementation of `struct picotm_os_rwlock` shall provide support
+ * for multiple concurrent readers if the operating system supports it.
+ */
+struct picotm_os_rwlock {
+    pthread_rwlock_t instance;
+};
+
+/**
+ * \brief Initializes an R/W-lock instance.
+ * \param self The R/W-lock instance to initialize.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_rwlock_init(struct picotm_os_rwlock* self,
+                      struct picotm_error* error);
+
+/**
+ * \brief Cleans-up an R/W-lock instance.
+ * \param self The R/W-lock instance to clean up.
+ */
+void
+picotm_os_rwlock_uninit(struct picotm_os_rwlock* self);
+
+/**
+ * \brief Acquires a reader lock.
+ * \param The R/W-lock instance to acquire.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_rwlock_rdlock(struct picotm_os_rwlock* self,
+                        struct picotm_error* error);
+
+/**
+ * \brief Acquires a writer lock.
+ * \param The R/W-lock instance to acquire.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_rwlock_wrlock(struct picotm_os_rwlock* self,
+                        struct picotm_error* error);
+
+/**
+ * \brief Releases an R/W lock.
+ * \param The R/W-lock instance to release.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_os_rwlock_unlock(struct picotm_os_rwlock* self);

--- a/src/picotm_os_timespec.c
+++ b/src/picotm_os_timespec.c
@@ -1,0 +1,93 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "picotm_os_timespec.h"
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-module.h"
+
+static const long MAX_NSEC = 999999999;
+
+void
+picotm_os_get_timespec(struct timespec* self,
+                       struct picotm_error* error)
+{
+    int res = clock_gettime(PICOTM_OS_TIMESPEC_CLOCKID, self);
+    if (res < 0) {
+        picotm_error_set_errno(error, errno);
+        return;
+    }
+}
+
+void
+picotm_os_add_timespec(struct timespec* lhs,
+                 const struct timespec* rhs)
+{
+    assert(lhs);
+    assert(rhs);
+
+    time_t carry = (MAX_NSEC - rhs->tv_nsec) < lhs->tv_nsec;
+
+    lhs->tv_sec += rhs->tv_sec + carry;
+    lhs->tv_nsec += rhs->tv_nsec;
+    lhs->tv_nsec -= (MAX_NSEC + 1) * !!carry;
+
+    assert(lhs->tv_nsec >= 0);
+    assert(lhs->tv_nsec <= MAX_NSEC);
+}
+
+void
+picotm_os_sub_timespec(struct timespec* lhs,
+                 const struct timespec* rhs)
+{
+    assert(lhs);
+    assert(rhs);
+
+    time_t carry = rhs->tv_nsec > lhs->tv_nsec;
+
+    lhs->tv_sec -= rhs->tv_sec - carry;
+    lhs->tv_nsec -= rhs->tv_nsec;
+    lhs->tv_nsec += (MAX_NSEC + 1) * !!carry;
+
+    assert(lhs->tv_nsec >= 0);
+    assert(lhs->tv_nsec <= MAX_NSEC);
+}
+
+void
+picotm_os_nanosleep(const struct timespec* sleep_time,
+                    struct picotm_error* error)
+{
+    struct timespec remaining_time, saved_remaining_time;
+
+    do {
+        int res = nanosleep(sleep_time, &remaining_time);
+        if (res < 0) {
+            if (errno != EINTR) {
+                picotm_error_set_errno(error, errno);
+                return;
+            }
+            sleep_time = memcpy(&saved_remaining_time, &remaining_time,
+                                sizeof(saved_remaining_time));
+            continue;
+        }
+        break;
+    } while (true);
+}

--- a/src/picotm_os_timespec.h
+++ b/src/picotm_os_timespec.h
@@ -1,0 +1,85 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <time.h>
+
+/**
+ * \cond impl || lib_impl
+ * \ingroup lib_impl
+ * \file
+ * \endcond
+ */
+
+struct picotm_error;
+struct timespec;
+
+/**
+ * CLOCK_REALTIME is the only clock supported by GNU libc's
+ * condition variables. Something like CLOCK_BOOTTIME or
+ * CLOCK_MONOTONIC_RAW would be ideal instead.
+ */
+static const clock_t PICOTM_OS_TIMESPEC_CLOCKID = CLOCK_REALTIME;
+
+/**
+ * \brief Retrieves the current time from the system.
+ * \param[out] self The retrieved time.
+ * \param[out] error Returns an error to the caller.
+ *
+ * The time returned by this function shall be compatible with the
+ * implementation of `struct picotm_os_cond`. The actual value, granularity
+ * and start time depends on the operating system and can vary among
+ * implementations.
+ */
+void
+picotm_os_get_timespec(struct timespec* self,
+                       struct picotm_error* error);
+
+/**
+ * \brief Adds two timespec values in place.
+ * \param[in,out] lhs Left-hand-side operator and result.
+ * \param rhs Right-hand-side operator.
+ */
+void
+picotm_os_add_timespec(struct timespec* restrict lhs,
+                 const struct timespec* restrict rhs);
+
+/**
+ * \brief Subtracts a timespec value from another in place.
+ * \param[in,out] lhs Left-hand-side operator and result.
+ * \param rhs Right-hand-side operator.
+ */
+void
+picotm_os_sub_timespec(struct timespec* restrict lhs,
+                 const struct timespec* restrict rhs);
+
+/**
+ * \brief Suspends the thread for a short period of time.
+ * \param sleep_time The time to sleep.
+ * \param[out] error Returns an error to the caller.
+ *
+ * This function provides a *low-overhead* way of suspending the calling
+ * thread for a short period of time. Implementations may not busy wait
+ * if possible. Depending on the system, threads may sleep longer than
+ * the specified period of time.
+ */
+void
+picotm_os_nanosleep(const struct timespec* sleep_time,
+                    struct picotm_error* error);

--- a/src/tx.c
+++ b/src/tx.c
@@ -361,10 +361,7 @@ tx_commit(struct tx* self, struct picotm_error* error)
         goto err;
     }
 
-    tx_shared_release_irrevocability(self->shared, error);
-    if (picotm_error_is_set(error)) {
-        goto err_out;
-    }
+    tx_shared_release_irrevocability(self->shared);
 
     return;
 
@@ -381,12 +378,7 @@ err:
     if (is_non_recoverable) {
         picotm_error_mark_as_non_recoverable(error);
     }
-    {
-        struct picotm_error err_error = PICOTM_ERROR_INITIALIZER;
-        tx_shared_release_irrevocability(self->shared, &err_error);
-    }
-err_out:
-    return;
+    tx_shared_release_irrevocability(self->shared);
 }
 
 void
@@ -416,21 +408,13 @@ tx_rollback(struct tx* self, struct picotm_error* error)
         goto err;
     }
 
-    tx_shared_release_irrevocability(self->shared, error);
-    if (picotm_error_is_set(error)) {
-        goto err_out;
-    }
+    tx_shared_release_irrevocability(self->shared);
 
     return;
 
 err:
     picotm_error_mark_as_non_recoverable(error);
-    {
-        struct picotm_error err_error = PICOTM_ERROR_INITIALIZER;
-        tx_shared_release_irrevocability(self->shared, &err_error);
-    }
-err_out:
-    return;
+    tx_shared_release_irrevocability(self->shared);
 }
 
 bool

--- a/src/tx.h
+++ b/src/tx.h
@@ -23,6 +23,7 @@
 #include "log.h"
 #include "module.h"
 #include "picotm/picotm.h"
+#include "picotm_lock_owner.h"
 
 /**
  * \cond impl || lib_impl
@@ -48,6 +49,9 @@ struct tx {
     enum tx_mode      mode;
     unsigned long     nretries;
 
+    /** The transaction's lock-owner instance. */
+    struct picotm_lock_owner lo;
+
     unsigned long nmodules; /**< \brief Number allocated modules */
     struct module module[MAX_NMODULES]; /** \brief Registered modules */
 
@@ -55,7 +59,8 @@ struct tx {
 };
 
 void
-tx_init(struct tx* self, struct tx_shared* tx_shared);
+tx_init(struct tx* self, struct tx_shared* tx_shared,
+        struct picotm_error* error);
 
 void
 tx_release(struct tx* self);

--- a/src/tx_shared.c
+++ b/src/tx_shared.c
@@ -20,6 +20,7 @@
 #include "tx_shared.h"
 #include <assert.h>
 #include "picotm/picotm-error.h"
+#include "picotm/picotm-module.h"
 
 void
 tx_shared_init(struct tx_shared* self, struct picotm_error* error)
@@ -32,6 +33,16 @@ tx_shared_init(struct tx_shared* self, struct picotm_error* error)
     }
 
     self->exclusive_tx = NULL;
+
+    picotm_lock_manager_init(&self->lm, error);
+    if (picotm_error_is_set(error)) {
+        goto err_lock_manager_init;
+    }
+
+    return;
+
+err_lock_manager_init:
+    picotm_os_rwlock_uninit(&self->exclusive_tx_lock);
 }
 
 void
@@ -39,6 +50,7 @@ tx_shared_uninit(struct tx_shared* self)
 {
     assert(self);
 
+    picotm_lock_manager_uninit(&self->lm);
     picotm_os_rwlock_uninit(&self->exclusive_tx_lock);
 }
 

--- a/src/tx_shared.h
+++ b/src/tx_shared.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <pthread.h>
+#include "picotm_os_rwlock.h"
 
 /**
  * \cond impl || lib_impl
@@ -34,21 +34,21 @@ struct picotm_error;
 struct tx_shared {
     /**
      * Locks the transaction system for either one exclusive transactions,
-     * or mutliple non-exclusive transactions.
+     * or multiple non-exclusive transactions.
      *
      * \todo This lock implements irrevocability. Replace this lock with a
      * more fine-grained system that allows recovable transactions while an
      * irrevocable transaction is present.
      */
-    pthread_rwlock_t exclusive_tx_lock;
-    struct tx*       exclusive_tx;
+    struct picotm_os_rwlock exclusive_tx_lock;
+    struct tx*              exclusive_tx;
 };
 
 void
 tx_shared_init(struct tx_shared* self, struct picotm_error* error);
 
 void
-tx_shared_uninit(struct tx_shared* self, struct picotm_error* error);
+tx_shared_uninit(struct tx_shared* self);
 
 void
 tx_shared_make_irrevocable(struct tx_shared* self, struct tx* exclusive_tx,
@@ -59,5 +59,4 @@ tx_shared_wait_irrevocable(struct tx_shared* self,
                            struct picotm_error* error);
 
 void
-tx_shared_release_irrevocability(struct tx_shared* self,
-                                 struct picotm_error* error);
+tx_shared_release_irrevocability(struct tx_shared* self);

--- a/src/tx_shared.h
+++ b/src/tx_shared.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "picotm_lock_manager.h"
 #include "picotm_os_rwlock.h"
 
 /**
@@ -42,6 +43,12 @@ struct tx_shared {
      */
     struct picotm_os_rwlock exclusive_tx_lock;
     struct tx*              exclusive_tx;
+
+    /**
+     * The global lock manager for all transactional locks. Register your
+     * transaction's lock-owner instance with this object.
+     */
+    struct picotm_lock_manager lm;
 };
 
 void


### PR DESCRIPTION
Each R/W lock now contains a list of waiters. Transactions act as waiters. The lock manager maintains the wait lists for each R/W lock and schedules waiters. This patch set contains all the infrastructure. A lot of tuning and adjustment for the different use cases and access patterns can be build on top of it.