### PR TITLE
lib: Move irrevocability support to lock manager

### DIFF
--- a/src/picotm_lock_manager.h
+++ b/src/picotm_lock_manager.h
@@ -51,6 +51,17 @@ struct picotm_lock_manager {
     struct picotm_os_rwlock    lo_rwlock;
     struct picotm_lock_owner** lo;
     size_t                     nlos;
+
+    /**
+     * Locks the transaction system for either one exclusive lock owner,
+     * or multiple non-exclusive lock owners.
+     *
+     * \todo This lock implements irrevocability. Replace this lock with a
+     * more fine-grained system that allows recovable transactions while an
+     * irrevocable transaction is present.
+     */
+    struct picotm_os_rwlock   exclusive_lo_lock;
+    struct picotm_lock_owner* exclusive_lo;
 };
 
 /**
@@ -96,6 +107,33 @@ picotm_lock_manager_register_owner(struct picotm_lock_manager* self,
 void
 picotm_lock_manager_unregister_owner(struct picotm_lock_manager* self,
                                      struct picotm_lock_owner* lo);
+
+/**
+ * \brief Sets irrevocability for a lock owner.
+ * \param self The lock manager.
+ * \param exclusive_lo The lock owner that is to become irrevocable.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_lock_manager_make_irrevocable(struct picotm_lock_manager* self,
+                                     struct picotm_lock_owner* exclusive_lo,
+                                     struct picotm_error* error);
+
+/**
+ * \brief Waits for an irrevocable lock owner to complete.
+ * \param self The lock manager.
+ * \param[out] error Returns an error to the caller.
+ */
+void
+picotm_lock_manager_wait_irrevocable(struct picotm_lock_manager* self,
+                                     struct picotm_error* error);
+
+/**
+ * \brief Unblocks irrevocability for other lock owners.
+ * \param self The lock manager.
+ */
+void
+picotm_lock_manager_release_irrevocability(struct picotm_lock_manager* self);
 
 /**
  * \brief Instructs a lock manager to setup a lock owner for waiting.

--- a/src/tx_shared.h
+++ b/src/tx_shared.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "picotm_lock_manager.h"
-#include "picotm_os_rwlock.h"
 
 /**
  * \cond impl || lib_impl
@@ -34,17 +33,6 @@ struct picotm_error;
 
 struct tx_shared {
     /**
-     * Locks the transaction system for either one exclusive transactions,
-     * or multiple non-exclusive transactions.
-     *
-     * \todo This lock implements irrevocability. Replace this lock with a
-     * more fine-grained system that allows recovable transactions while an
-     * irrevocable transaction is present.
-     */
-    struct picotm_os_rwlock exclusive_tx_lock;
-    struct tx*              exclusive_tx;
-
-    /**
      * The global lock manager for all transactional locks. Register your
      * transaction's lock-owner instance with this object.
      */
@@ -56,14 +44,3 @@ tx_shared_init(struct tx_shared* self, struct picotm_error* error);
 
 void
 tx_shared_uninit(struct tx_shared* self);
-
-void
-tx_shared_make_irrevocable(struct tx_shared* self, struct tx* exclusive_tx,
-                           struct picotm_error* error);
-
-void
-tx_shared_wait_irrevocable(struct tx_shared* self,
-                           struct picotm_error* error);
-
-void
-tx_shared_release_irrevocability(struct tx_shared* self);


### PR DESCRIPTION
This patch moves the irrevocability code from the shared transaction
state to the lock manager. No changes to the implementation are made.

Irrevocable transactions currently run exclusivly. With integration
into the lock manager, future patch sets can add support for non-exclusive
irrevocable transactions.