### PR TITLE
libc: Fix getcwd_tx()

### DIFF
--- a/modules/libc/src/cwd/cwd_tx.c
+++ b/modules/libc/src/cwd/cwd_tx.c
@@ -269,7 +269,7 @@ cwd_tx_getcwd_exec(struct cwd_tx* self, char* buf, size_t size,
         cwdop->data.getcwd.alloced_cwd = NULL;
     }
 
-    append_event(self, CMD_CHDIR, cwdop, error);
+    append_event(self, CMD_GETCWD, cwdop, error);
     if (picotm_error_is_set(error)) {
         goto err_append_event;
     }

--- a/modules/libc/tests/pubapi/Makefile.am
+++ b/modules/libc/tests/pubapi/Makefile.am
@@ -18,6 +18,8 @@
 
 TESTS = allocator-pubapi-t1.test \
         allocator-pubapi-t4.test \
+        cwd-pubapi-t1.test \
+        cwd-pubapi-t4.test \
         fildes-pubapi-t1.test \
         fildes-pubapi-t4.test \
         vfs-pubapi-t1.test \
@@ -29,6 +31,7 @@ TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(top_srcdir)/build-aux/tap-driver.sh
 
 check_PROGRAMS = allocator-pubapi.test \
+                 cwd-pubapi.test \
                  fildes-pubapi.test \
                  vfs-pubapi.test
 
@@ -37,6 +40,12 @@ allocator_pubapi_test_SOURCES = delay.c \
                                 allocator_pubapi.c \
                                 allocator_test.c \
                                 allocator_test.h
+
+cwd_pubapi_test_SOURCES = cwd_pubapi.c \
+                          cwd_test.c \
+                          cwd_test.h \
+                          delay.c \
+                          delay.h
 
 fildes_pubapi_test_SOURCES = delay.c \
                              delay.h \

--- a/modules/libc/tests/pubapi/cwd-pubapi-t1.test
+++ b/modules/libc/tests/pubapi/cwd-pubapi-t1.test
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+./cwd-pubapi.test -t1
+
+echo $?

--- a/modules/libc/tests/pubapi/cwd-pubapi-t4.test
+++ b/modules/libc/tests/pubapi/cwd-pubapi-t4.test
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+./cwd-pubapi.test -t4
+
+echo $?

--- a/modules/libc/tests/pubapi/cwd_pubapi.c
+++ b/modules/libc/tests/pubapi/cwd_pubapi.c
@@ -1,0 +1,69 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "opts.h"
+#include "tap.h"
+#include "test.h"
+#include "cwd_test.h"
+
+int
+main(int argc, char** argv)
+{
+    switch (parse_opts(argc, argv, PARSE_OPTS_STRING())) {
+        case PARSE_OPTS_EXIT:
+            return EXIT_SUCCESS;
+        case PARSE_OPTS_ERROR:
+            return EXIT_FAILURE;
+        default:
+            break;
+    }
+
+    if (number_of_cwd_tests() <= g_off) {
+        fprintf(stderr, "Test index out of range\n");
+        return EXIT_FAILURE;
+    }
+
+    size_t off = g_off;
+    size_t num;
+
+    if (!g_num) {
+        num = number_of_cwd_tests() - off;
+    } else {
+        num = g_num;
+    }
+
+    if (number_of_cwd_tests() < (off + g_num)) {
+        fprintf(stderr, "Test index out of range\n");
+        return EXIT_FAILURE;
+    }
+
+    /* run tests  */
+
+    tap_version(12);
+
+    const struct test_func* test_beg = cwd_test + off;
+    const struct test_func* test_end = cwd_test + off + num;
+
+    run_tests(test_beg, test_end, g_nthreads, g_loop, g_btype, g_cycles);
+
+    return EXIT_SUCCESS;
+}

--- a/modules/libc/tests/pubapi/cwd_test.c
+++ b/modules/libc/tests/pubapi/cwd_test.c
@@ -1,0 +1,70 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "cwd_test.h"
+#include <picotm/picotm.h>
+#include <picotm/picotm-tm.h>
+#include <picotm/unistd.h>
+#include <string.h>
+#include "delay.h"
+#include "ptr.h"
+#include "safeblk.h"
+#include "safe_unistd.h"
+#include "taputils.h"
+#include "testhlp.h"
+
+/**
+ * Test getcwd()
+ */
+
+static void
+cwd_test_1(unsigned int tid)
+{
+    const char* cwd = safe_getcwd(NULL, 0);
+
+	picotm_begin
+
+        privatize_c_tx(cwd, '\0', PICOTM_TM_PRIVATIZE_LOAD);
+
+        char* cwd_tx = getcwd_tx(NULL, 0);
+
+        if (strcmp(cwd, cwd_tx)) {
+            tap_error("working directories did not match:"
+                      " expected '%s', got '%s'\n", cwd, cwd_tx);
+            abort_safe_block();
+        }
+
+        delay_transaction(tid);
+
+    picotm_commit
+
+        abort_transaction_on_error(__func__);
+
+	picotm_end
+}
+
+const struct test_func cwd_test[] = {
+    {"cwd_test_1", cwd_test_1, NULL, NULL},
+};
+
+size_t
+number_of_cwd_tests()
+{
+    return arraylen(cwd_test);
+}

--- a/modules/libc/tests/pubapi/cwd_test.h
+++ b/modules/libc/tests/pubapi/cwd_test.h
@@ -1,0 +1,28 @@
+/* Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include "test.h"
+
+extern const struct test_func cwd_test[];
+
+size_t
+number_of_cwd_tests(void);

--- a/tests/libtests/safe_unistd.c
+++ b/tests/libtests/safe_unistd.c
@@ -34,6 +34,17 @@ safe_close(int fd)
     return res;
 }
 
+char*
+safe_getcwd(char* buf, size_t size)
+{
+    char* cwd = getcwd(buf, size);;
+    if (!cwd) {
+        tap_error_errno("getcwd()", errno);
+        abort_safe_block();
+    }
+    return cwd;
+}
+
 int
 safe_pipe(int pipefd[2])
 {

--- a/tests/libtests/safe_unistd.h
+++ b/tests/libtests/safe_unistd.h
@@ -24,6 +24,9 @@
 int
 safe_close(int fd);
 
+char*
+safe_getcwd(char* buf, size_t size);
+
 int
 safe_pipe(int pipefd[2]);
 


### PR DESCRIPTION
The execute function of getcwd_tx() appends the wrong event to the log. This patch fixes the issue and additionally adds a test case for getcwd_tx()