### PR TITLE
libc: Fix open_tx()

### DIFF
--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -763,18 +763,20 @@ absolute_path(const char* path, struct picotm_error* error)
     size_t pathlen = strlen(path);
     size_t cwdlen = strlen(cwd);
 
-    char* abs_path = malloc(pathlen + cwdlen + 2 * sizeof(*abs_path));
+    size_t len = cwdlen + 1 + pathlen + 1;
+
+    char* abs_path = malloc(len * sizeof(*abs_path));
     if (!abs_path) {
         picotm_error_set_errno(error, errno);
         goto err_malloc;
     }
 
-    memcpy(abs_path, path, pathlen);
-    abs_path[pathlen] = '/';
-    memcpy(abs_path + pathlen + 1, cwd, cwdlen);
-    abs_path[pathlen + 1 + cwdlen] = '\0';
+    memcpy(abs_path, cwd, cwdlen);
+    abs_path[cwdlen] = '/';
+    memcpy(abs_path + cwdlen + 1, path, pathlen);
+    abs_path[cwdlen + 1 + pathlen] = '\0';
 
-    allocator_module_free(cwd, strlen(cwd));
+    allocator_module_free(cwd, cwdlen);
 
     return abs_path;
 

--- a/tests/libtests/safe_unistd.c
+++ b/tests/libtests/safe_unistd.c
@@ -24,6 +24,17 @@
 #include "taputils.h"
 
 int
+safe_chdir(const char* path)
+{
+    int res = TEMP_FAILURE_RETRY(chdir(path));
+    if (res < 0) {
+        tap_error_errno("chdir()", errno);
+        abort_safe_block();
+    }
+    return res;
+}
+
+int
 safe_close(int fd)
 {
     int res = TEMP_FAILURE_RETRY(close(fd));

--- a/tests/libtests/safe_unistd.h
+++ b/tests/libtests/safe_unistd.h
@@ -22,6 +22,9 @@
 #include <sys/types.h>
 
 int
+safe_chdir(const char* path);
+
+int
 safe_close(int fd);
 
 char*


### PR DESCRIPTION
This patch set fixes a problem when calling open_tx() with a relative path. The path resolution did not work correctly in this case. The patch set also adds a test case for this problem.