### PR TITLE
Garbage-collect unused symbols when linking binaries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,17 @@ dnl exported explicitly.
 AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],
                       [CFLAGS="$CFLAGS -fvisibility=hidden"])
 
+dnl Garbage-collect unused functions and data. This is mostly
+dnl useful for reducing the size of statically linked binaries.
+AX_CHECK_LINK_FLAG([-Wl,--gc-sections],
+                   [LDFLAGS="$LDFLAGS -Wl,--gc-sections"]
+                   [AX_CHECK_COMPILE_FLAG(
+                        [-ffunction-sections],
+                        [CFLAGS="$CFLAGS -ffunction-sections"])]
+                   [AX_CHECK_COMPILE_FLAG(
+                        [-fdata-sections],
+                        [CFLAGS="$CFLAGS -fdata-sections"])])
+
 
 dnl
 dnl Build toolchain


### PR DESCRIPTION
This patch adds support for compiler and linker flags that can reduce
the size of the produced binary files significantly. For statically
linked binaries, only the actually used functions and data is included
by the linker. The unlinked static library may be much larger though.
There's only a small effect on shared objects.