### PR TITLE
lib: Don't release irrevocability in tx_commit() on errors

### DIFF
--- a/src/tx.c
+++ b/src/tx.c
@@ -413,7 +413,6 @@ err:
     if (is_non_recoverable) {
         picotm_error_mark_as_non_recoverable(error);
     }
-    picotm_lock_manager_release_irrevocability(&self->shared->lm);
 }
 
 void


### PR DESCRIPTION
Irrevocability state is always releases after a successful commit or
during roll-back. This patch removes an incorrect release call after
an error has been observed by tx_commit().