### PR TITLE
lib: Store jump buffer on thread-local stack

### DIFF
--- a/src/tx.c
+++ b/src/tx.c
@@ -41,6 +41,7 @@ tx_init(struct tx* self, struct tx_shared* tx_shared,
 
     log_init(&self->log);
 
+    self->env = NULL;
     self->shared = tx_shared;
     self->mode = TX_MODE_REVOCABLE;
     self->nretries = 0;
@@ -138,7 +139,7 @@ tx_append_event(struct tx* self, unsigned long module, unsigned long op,
 }
 
 void
-tx_begin(struct tx* self, enum tx_mode mode, bool is_retry,
+tx_begin(struct tx* self, enum tx_mode mode, bool is_retry, jmp_buf* env,
          struct picotm_error* error)
 {
     assert(self);
@@ -177,6 +178,7 @@ tx_begin(struct tx* self, enum tx_mode mode, bool is_retry,
 
     self->nretries = nretries;
     self->mode = mode;
+    self->env = env;
 
     return;
 

--- a/src/tx.h
+++ b/src/tx.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <setjmp.h>
 #include <stdbool.h>
 #include "log.h"
 #include "module.h"
-#include "picotm/picotm.h"
 #include "picotm_lock_owner.h"
 
 /**
@@ -43,7 +43,7 @@ enum tx_mode {
 };
 
 struct tx {
-    struct __picotm_tx public_state;
+    jmp_buf*          env;
     struct log        log;
     struct tx_shared *shared;
     enum tx_mode      mode;
@@ -91,7 +91,7 @@ tx_append_event(struct tx* self, unsigned long module, unsigned long op,
                 uintptr_t cookie, struct picotm_error* error);
 
 void
-tx_begin(struct tx* self, enum tx_mode mode, bool is_retry,
+tx_begin(struct tx* self, enum tx_mode mode, bool is_retry, jmp_buf* env,
          struct picotm_error* error);
 
 void


### PR DESCRIPTION
The jump buffer for returning to the beginning of the transaction
was stored in the thread-local transaction state. Initializaton of
this state can fail and the transaction would roll back. Since there
is not yet a valid jump buffer, the roll-back would fail and move
into an undefined state.

This patch changes picotm's interface and implementation such that
the jump buffer is stored on the thread's stack before entering a
transaction and it's initialized before the transaction state. If
initialization of the transaction state fails, the transaction can
will now enter recovery mode directly.