### PR TITLE
Store internal configuration header in config/

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_PREREQ([2.69])
 AC_INIT([picotm], [0.8.0], [bugs@picotm.org], [], [http://picotm.org])
 
 dnl Internal configuration header
-AC_CONFIG_HEADERS([include/picotm/config.h])
+AC_CONFIG_HEADERS([config/config.h])
 
 AC_CONFIG_SRCDIR([src/Makefile.am])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/modules/libc/src/Makefile.am
+++ b/modules/libc/src/Makefile.am
@@ -156,4 +156,4 @@ AM_CPPFLAGS = -I$(top_builddir)/modules/libc/include \
               -I$(top_srcdir)/modules/tm/include \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/modules/libc/tests/pubapi/Makefile.am
+++ b/modules/libc/tests/pubapi/Makefile.am
@@ -68,4 +68,4 @@ AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
               -I$(top_srcdir)/modules/tm/include \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/modules/libm/src/Makefile.am
+++ b/modules/libm/src/Makefile.am
@@ -43,4 +43,4 @@ AM_CPPFLAGS = -I$(top_builddir)/modules/libm/include \
               -I$(top_srcdir)/modules/tm/include \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/modules/libpthread/src/Makefile.am
+++ b/modules/libpthread/src/Makefile.am
@@ -32,4 +32,4 @@ AM_CPPFLAGS = -I$(top_builddir)/modules/libpthread/include \
               -I$(top_srcdir)/modules/tm/include \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/modules/tm/src/Makefile.am
+++ b/modules/tm/src/Makefile.am
@@ -43,4 +43,4 @@ AM_CPPFLAGS = -I$(top_builddir)/modules/tm/include \
               -I$(top_srcdir)/modules/tm/include \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/modules/tm/tests/pubapi/Makefile.am
+++ b/modules/tm/tests/pubapi/Makefile.am
@@ -45,4 +45,4 @@ AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
               -I$(top_srcdir)/modules/tm/include \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/modules/txlib/src/Makefile.am
+++ b/modules/txlib/src/Makefile.am
@@ -67,4 +67,4 @@ AM_CPPFLAGS = -I$(top_builddir)/modules/txlib/include \
               -I$(top_srcdir)/modules/txlib/include \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/modules/txlib/tests/pubapi/Makefile.am
+++ b/modules/txlib/tests/pubapi/Makefile.am
@@ -66,4 +66,4 @@ AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
               -I$(top_srcdir)/modules/txlib/include \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,4 +59,4 @@ libpicotm_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
 AM_CPPFLAGS = -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/tests/libtap/Makefile.am
+++ b/tests/libtap/Makefile.am
@@ -25,4 +25,4 @@ libpicotm_tap_la_SOURCES = tap.c \
 
 AM_CPPFLAGS = -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/tests/libtests/Makefile.am
+++ b/tests/libtests/Makefile.am
@@ -50,4 +50,4 @@ AM_CPPFLAGS = -I$(top_builddir)/tests/libtap \
               -I$(top_srcdir)/tests/libtap \
               -I$(top_builddir)/include \
               -I$(top_srcdir)/include \
-              -include picotm/config.h
+              -include config.h

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -22,6 +22,7 @@
 # build infrastructure.
 
 test -d build-aux/ || mkdir -p build-aux/ || exit $?
+test -d config/ || mkdir -p config/ || exit $?
 test -d m4/ || mkdir -p m4/ || exit $?
 
 test -e ChangeLog || touch ChangeLog || exit $?


### PR DESCRIPTION
The configuration header's path is automatically added to the list of
include search directories. This can lead to problems with other header
files if the configuration is stored directly in picotm's include directory.

This patch moves the configuration header to it's own, separate
directory.