### PR TITLE
libc: Decode `mode_t` as type `int` in va_arg()

### DIFF
--- a/modules/libc/src/fcntl-tm.c
+++ b/modules/libc/src/fcntl-tm.c
@@ -18,6 +18,7 @@
  */
 
 #include "picotm/fcntl-tm.h"
+#include <assert.h>
 #include <errno.h>
 #include <picotm/picotm-module.h>
 #include <stdarg.h>
@@ -101,9 +102,17 @@ open_tm(const char* path, int oflag, ...)
     mode_t mode = 0;
 
     if (oflag & O_CREAT) {
+
+        /* The optional third argument is of type `mode_t`. It's
+         * decoded as `int`. If `mode_t` has a conversion rank
+         * larger than `int`, we have to adapt the call to
+         * va_arg(). */
+        static_assert(sizeof(mode_t) <= sizeof(int),
+                      "`mode_t` has incorrect size");
+
         va_list arg;
         va_start(arg, oflag);
-        mode = va_arg(arg, mode_t);
+        mode = va_arg(arg, int);
         va_end(arg);
     }
 

--- a/modules/libc/src/fcntl.c
+++ b/modules/libc/src/fcntl.c
@@ -18,6 +18,7 @@
  */
 
 #include "picotm/fcntl.h"
+#include <assert.h>
 #include <errno.h>
 #include <picotm/picotm-module.h>
 #include <picotm/picotm-tm.h>
@@ -103,9 +104,16 @@ open_tx(const char* path, int oflag, ...)
         return open_tm(path, oflag);
     }
 
+    /* The optional third argument is of type `mode_t`. It's
+     * decoded as `int`. If `mode_t` has a conversion rank
+     * larger than `int`, we have to adapt the call to
+     * va_arg(). */
+    static_assert(sizeof(mode_t) <= sizeof(int),
+                  "`mode_t` has incorrect size");
+
     va_list arg;
     va_start(arg, oflag);
-    mode_t mode = va_arg(arg, mode_t);
+    mode_t mode = va_arg(arg, int);
     va_end(arg);
 
     return open_tm(path, oflag, mode);


### PR DESCRIPTION
The type of `mode_t` might have a conversion rank lower than `int`. A
parameter of `mode_t` will be promoted to `int`. Decoding variable-
argument parameters as `mode_t` then results in undefined behaviour. This
is the case on at least FreeBSD systems.

This patch changes the call to `va_arg()` to decode `mode_t` as `int`
when passed to `open_tx()` and `open_tm()`.