### PR TITLE
tests: Replace safe_pthread_yield() with safe_sched_yield()

### DIFF
--- a/modules/txlib/tests/pubapi/txlist_test.c
+++ b/modules/txlib/tests/pubapi/txlist_test.c
@@ -28,7 +28,7 @@
 #include "picotm/picotm-txlist.h"
 #include "ptr.h"
 #include "safeblk.h"
-#include "safe_pthread.h"
+#include "safe_sched.h"
 #include "safe_stdio.h"
 #include "safe_stdlib.h"
 #include "taputils.h"
@@ -488,7 +488,7 @@ txlist_test_7(unsigned int tid)
 
     picotm_end
 
-    safe_pthread_yield();
+    safe_sched_yield();
 
     /* Compare values; consecutive items should have same value. */
 
@@ -530,7 +530,7 @@ txlist_test_7(unsigned int tid)
 
     picotm_end
 
-    safe_pthread_yield();
+    safe_sched_yield();
 
     /* Remove all items with local TID from shared list. */
 

--- a/modules/txlib/tests/pubapi/txmultiset_test.c
+++ b/modules/txlib/tests/pubapi/txmultiset_test.c
@@ -29,7 +29,7 @@
 #include "picotm/picotm-txmultiset.h"
 #include "ptr.h"
 #include "safeblk.h"
-#include "safe_pthread.h"
+#include "safe_sched.h"
 #include "safe_stdio.h"
 #include "safe_stdlib.h"
 #include "taputils.h"
@@ -749,7 +749,7 @@ txmultiset_test_8(unsigned int tid)
 
     picotm_end
 
-    safe_pthread_yield();
+    safe_sched_yield();
 
     /* Compare values; consecutive items should have same value. */
 
@@ -791,7 +791,7 @@ txmultiset_test_8(unsigned int tid)
 
     picotm_end
 
-    safe_pthread_yield();
+    safe_sched_yield();
 
     /* Remove all items with local TID from shared multiset. */
 

--- a/modules/txlib/tests/pubapi/txqueue_test.c
+++ b/modules/txlib/tests/pubapi/txqueue_test.c
@@ -28,7 +28,7 @@
 #include "picotm/picotm-txqueue.h"
 #include "ptr.h"
 #include "safeblk.h"
-#include "safe_pthread.h"
+#include "safe_sched.h"
 #include "safe_stdio.h"
 #include "safe_stdlib.h"
 #include "taputils.h"
@@ -318,7 +318,7 @@ txqueue_test_4(unsigned int tid)
 
     picotm_end
 
-    safe_pthread_yield();
+    safe_sched_yield();
 
     /* Compare values; consecutive items should have same value. */
 

--- a/modules/txlib/tests/pubapi/txstack_test.c
+++ b/modules/txlib/tests/pubapi/txstack_test.c
@@ -28,7 +28,7 @@
 #include "picotm/picotm-txstack.h"
 #include "ptr.h"
 #include "safeblk.h"
-#include "safe_pthread.h"
+#include "safe_sched.h"
 #include "safe_stdio.h"
 #include "safe_stdlib.h"
 #include "taputils.h"
@@ -302,7 +302,7 @@ txstack_test_4(unsigned int tid)
 
     picotm_end
 
-    safe_pthread_yield();
+    safe_sched_yield();
 
     /* Compare values; consecutive items should have same value. */
 

--- a/tests/libtests/Makefile.am
+++ b/tests/libtests/Makefile.am
@@ -27,6 +27,8 @@ libpicotm_tests_la_SOURCES = opts.c \
                              safe_fcntl.h \
                              safe_pthread.c \
                              safe_pthread.h \
+                             safe_sched.c \
+                             safe_sched.h \
                              safe_stdio.c \
                              safe_stdio.h \
                              safe_stdlib.c \

--- a/tests/libtests/safe_pthread.c
+++ b/tests/libtests/safe_pthread.c
@@ -100,14 +100,3 @@ safe_pthread_mutex_unlock(pthread_mutex_t* mutex)
     }
     return err;
 }
-
-int
-safe_pthread_yield()
-{
-    int err = pthread_yield();
-    if (err) {
-        tap_error_errno("pthread_mutex_yield()", err);
-        abort_safe_block();
-    }
-    return err;
-}

--- a/tests/libtests/safe_sched.c
+++ b/tests/libtests/safe_sched.c
@@ -17,30 +17,17 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#pragma once
-
-#include <pthread.h>
-
-int
-safe_pthread_barrier_destroy(pthread_barrier_t* barrier);
+#include "safe_sched.h"
+#include "safeblk.h"
+#include "taputils.h"
 
 int
-safe_pthread_barrier_init(pthread_barrier_t* restrict barrier,
-                          const pthread_barrierattr_t* restrict attr,
-                          unsigned count);
-
-int
-safe_pthread_barrier_wait(pthread_barrier_t* barrier);
-
-int
-safe_pthread_create(pthread_t* thread, const pthread_attr_t* attr,
-                    void* (*start_routine)(void*), void* arg);
-
-int
-safe_pthread_join(pthread_t thread, void** retval);
-
-int
-safe_pthread_mutex_lock(pthread_mutex_t* mutex);
-
-int
-safe_pthread_mutex_unlock(pthread_mutex_t* mutex);
+safe_sched_yield()
+{
+    int err = sched_yield();
+    if (err) {
+        tap_error_errno("sched_yield()", err);
+        abort_safe_block();
+    }
+    return err;
+}

--- a/tests/libtests/safe_sched.h
+++ b/tests/libtests/safe_sched.h
@@ -19,28 +19,7 @@
 
 #pragma once
 
-#include <pthread.h>
+#include <sched.h>
 
 int
-safe_pthread_barrier_destroy(pthread_barrier_t* barrier);
-
-int
-safe_pthread_barrier_init(pthread_barrier_t* restrict barrier,
-                          const pthread_barrierattr_t* restrict attr,
-                          unsigned count);
-
-int
-safe_pthread_barrier_wait(pthread_barrier_t* barrier);
-
-int
-safe_pthread_create(pthread_t* thread, const pthread_attr_t* attr,
-                    void* (*start_routine)(void*), void* arg);
-
-int
-safe_pthread_join(pthread_t thread, void** retval);
-
-int
-safe_pthread_mutex_lock(pthread_mutex_t* mutex);
-
-int
-safe_pthread_mutex_unlock(pthread_mutex_t* mutex);
+safe_sched_yield(void);


### PR DESCRIPTION
The function sched_yield() is prefered over pthread_yield() as
it's standardized by POSIX. This patch replaces all occurences
of safe_pthread_yield() and removes the function.