### PR TITLE
txlib: Add entry init/uninit functions for transactional memory

### DIFF
--- a/modules/txlib/include/picotm/picotm-txlist.h
+++ b/modules/txlib/include/picotm/picotm-txlist.h
@@ -40,6 +40,30 @@ PICOTM_BEGIN_DECLS
  * \brief Provides transactional lists
  */
 
+PICOTM_NOTHROW
+/**
+ * \brief Initializes an entry of a transactional list from within a
+ *        transaction.
+ * \param self The list entry to initialize.
+ * \attention This function expects the entry's memory to be owned by
+ *            the calling transaction. Shared-memory locations have to
+ *            be read/write privatized first.
+ */
+void
+txlist_entry_init_tm(struct txlist_entry* self);
+
+PICOTM_NOTHROW
+/**
+ * \brief Cleans up an entry of a transactional list from within a
+ *        transaction.
+ * \param self The list entry to clean up.
+ * \attention This function expects the entry's memory to be owned by
+ *            the calling transaction. Shared-memory locations have to
+ *            be read/write privatized first.
+ */
+void
+txlist_entry_uninit_tm(struct txlist_entry* self);
+
 /**
  * \struct txlist
  * \brief A handle for operating on transaction-safe lists.

--- a/modules/txlib/include/picotm/picotm-txmultiset.h
+++ b/modules/txlib/include/picotm/picotm-txmultiset.h
@@ -40,6 +40,30 @@ PICOTM_BEGIN_DECLS
  * \brief Provides transactional multisets
  */
 
+PICOTM_NOTHROW
+/**
+ * \brief Initializes an entry of a transactional multiset from within a
+ *        transaction.
+ * \param self The multiset entry to initialize.
+ * \attention This function expects the entry's memory to be owned by
+ *            the calling transaction. Shared-memory locations have to
+ *            be read/write privatized first.
+ */
+void
+txmultiset_entry_init_tm(struct txmultiset_entry* self);
+
+PICOTM_NOTHROW
+/**
+ * \brief Cleans up an entry of a transactional multiset from within a
+ *        transaction.
+ * \param self The multiset entry to clean up.
+ * \attention This function expects the entry's memory to be owned by
+ *            the calling transaction. Shared-memory locations have to
+ *            be read/write privatized first.
+ */
+void
+txmultiset_entry_uninit_tm(struct txmultiset_entry* self);
+
 /**
  * \struct txmultiset
  * \brief A handle for operating on transaction-safe multisets.

--- a/modules/txlib/include/picotm/picotm-txqueue.h
+++ b/modules/txlib/include/picotm/picotm-txqueue.h
@@ -40,6 +40,29 @@ PICOTM_BEGIN_DECLS
  * \brief Provides transactional queues
  */
 
+PICOTM_NOTHROW
+/**
+ * \brief Initializes an entry of a transactional queue from within a
+ *        transaction.
+ * \param self The queue entry to initialize.
+ * \attention This function expects the entry's memory to be owned by
+ *            the calling transaction. Shared-memory locations have to
+ *            be read/write privatized first.
+ */
+void
+txqueue_entry_init_tm(struct txqueue_entry* self);
+
+PICOTM_NOTHROW
+/**
+ * \brief Cleans up an entry of a transactional queue.
+ * \param self The queue entry to clean up.
+ * \attention This function expects the entry's memory to be owned by
+ *            the calling transaction. Shared-memory locations have to
+ *            be read/write privatized first.
+ */
+void
+txqueue_entry_uninit_tm(struct txqueue_entry* self);
+
 /**
  * \struct txqueue
  * \brief A handle for operating on transaction-safe queues.

--- a/modules/txlib/include/picotm/picotm-txstack.h
+++ b/modules/txlib/include/picotm/picotm-txstack.h
@@ -282,6 +282,30 @@ PICOTM_BEGIN_DECLS
  * ~~~
  */
 
+PICOTM_NOTHROW
+/**
+ * \brief Initializes an entry of a transactional stack from within a
+ *        transaction.
+ * \param self The stack entry to initialize.
+ * \attention This function expects the entry's memory to be owned by
+ *            the calling transaction. Shared-memory locations have to
+ *            be read/write privatized first.
+ */
+void
+txstack_entry_init_tm(struct txstack_entry* self);
+
+PICOTM_NOTHROW
+/**
+ * \brief Cleans up an entry of a transactional stack from within a
+ *        transaction.
+ * \param self The stack entry to clean up.
+ * \attention This function expects the entry's memory to be owned by
+ *            the calling transaction. Shared-memory locations have to
+ *            be read/write privatized first.
+ */
+void
+txstack_entry_uninit_tm(struct txstack_entry* self);
+
 /**
  * \struct txstack
  * \brief A handle for operating on transaction-safe stacks.

--- a/modules/txlib/src/txlist.c
+++ b/modules/txlib/src/txlist.c
@@ -29,6 +29,20 @@
 #include "txlib_module.h"
 #include "txlist_tx.h"
 
+PICOTM_EXPORT
+void
+txlist_entry_init_tm(struct txlist_entry* self)
+{
+    txlist_entry_init(self);
+}
+
+PICOTM_EXPORT
+void
+txlist_entry_uninit_tm(struct txlist_entry* self)
+{
+    txlist_entry_uninit(self);
+}
+
 static struct txlist*
 list_of_list_tx(struct txlist_tx* list_tx)
 {

--- a/modules/txlib/src/txmultiset.c
+++ b/modules/txlib/src/txmultiset.c
@@ -29,6 +29,20 @@
 #include "txlib_module.h"
 #include "txmultiset_tx.h"
 
+PICOTM_EXPORT
+void
+txmultiset_entry_init_tm(struct txmultiset_entry* self)
+{
+    txmultiset_entry_init(self);
+}
+
+PICOTM_EXPORT
+void
+txmultiset_entry_uninit_tm(struct txmultiset_entry* self)
+{
+    txmultiset_entry_uninit(self);
+}
+
 static struct txmultiset*
 multiset_of_multiset_tx(struct txmultiset_tx* multiset_tx)
 {

--- a/modules/txlib/src/txqueue.c
+++ b/modules/txlib/src/txqueue.c
@@ -29,6 +29,20 @@
 #include "txlib_module.h"
 #include "txqueue_tx.h"
 
+PICOTM_EXPORT
+void
+txqueue_entry_init_tm(struct txqueue_entry* self)
+{
+    txqueue_entry_init(self);
+}
+
+PICOTM_EXPORT
+void
+txqueue_entry_uninit_tm(struct txqueue_entry* self)
+{
+    txqueue_entry_uninit(self);
+}
+
 static struct txqueue*
 queue_of_queue_tx(struct txqueue_tx* queue_tx)
 {

--- a/modules/txlib/src/txstack.c
+++ b/modules/txlib/src/txstack.c
@@ -29,6 +29,20 @@
 #include "txlib_module.h"
 #include "txstack_tx.h"
 
+PICOTM_EXPORT
+void
+txstack_entry_init_tm(struct txstack_entry* self)
+{
+    txstack_entry_init(self);
+}
+
+PICOTM_EXPORT
+void
+txstack_entry_uninit_tm(struct txstack_entry* self)
+{
+    txstack_entry_uninit(self);
+}
+
 static struct txstack*
 stack_of_stack_tx(struct txstack_tx* stack_tx)
 {


### PR DESCRIPTION
This patch adds initializer and clean-up functions for entries of
txlib data structures. With these helpers entries can be allocated
and initialized from within tranactions, or cleaned up and freed
from within transactions. All helpers expect the entry's memory
location to be owned by the calling transaction.