### PR TITLE
core: Enable auto-generation of documentation for `kern_return_t`

### DIFF
--- a/include/picotm/picotm-error.h
+++ b/include/picotm/picotm-error.h
@@ -183,7 +183,7 @@ picotm_error_set_errno(struct picotm_error* error, int errno_hint);
 
 #if defined(PICOTM_HAVE_TYPE_KERN_RETURN_T) && \
         PICOTM_HAVE_TYPE_KERN_RETURN_T || \
-    defined(_PICOTM_DOXYGEN)
+    defined(__PICOTM_DOXYGEN)
 PICOTM_NOTHROW
 /**
  * Sets an error of type PICOTM_KERN_RETURN_T.

--- a/include/picotm/picotm-module.h
+++ b/include/picotm/picotm-module.h
@@ -245,7 +245,7 @@ picotm_recover_from_errno(int errno_hint);
 
 #if defined(PICOTM_HAVE_TYPE_KERN_RETURN_T) && \
         PICOTM_HAVE_TYPE_KERN_RETURN_T || \
-    defined(_PICOTM_DOXYGEN)
+    defined(__PICOTM_DOXYGEN)
 PICOTM_NOTHROW
 /**
  * Instructs the transaction management system to recover from an error

--- a/include/picotm/picotm.h
+++ b/include/picotm/picotm.h
@@ -212,7 +212,7 @@ picotm_error_as_errno(void);
 
 #if defined(PICOTM_HAVE_TYPE_KERN_RETURN_T) && \
         PICOTM_HAVE_TYPE_KERN_RETURN_T || \
-    defined(_PICOTM_DOXYGEN)
+    defined(__PICOTM_DOXYGEN)
 /**
  * Returns the current picotm kern_return_t value.
  *


### PR DESCRIPTION
This patch fixes the documentation macros for `kern_return_t`.