### PR TITLE
Optional modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,16 +139,22 @@ dnl
 
 AC_CONFIG_HEADERS([modules/cast/include/picotm/config/picotm-cast-config.h])
 CONFIG_CAST
+CONFIG_TEST([modules/cast/tests/pubapi/cast-pubapi-valgrind-t1.test])
 
 AC_CONFIG_HEADERS(
     [modules/arithmetic/include/picotm/config/picotm-arithmetic-config.h])
 CONFIG_ARITHMETIC
+CONFIG_TEST([modules/arithmetic/tests/pubapi/arithmetic-pubapi-valgrind-t1.test])
 
 AC_CONFIG_HEADERS([modules/tm/include/picotm/config/picotm-tm-config.h])
 CONFIG_TM
+CONFIG_TEST([modules/tm/tests/pubapi/tm-pubapi-valgrind-t1.test])
 
 AC_CONFIG_HEADERS([modules/libc/include/picotm/config/picotm-libc-config.h])
 CONFIG_LIBC
+CONFIG_TEST([modules/libc/tests/pubapi/allocator-pubapi-valgrind-t1.test])
+CONFIG_TEST([modules/libc/tests/pubapi/cwd-pubapi-valgrind-t1.test])
+CONFIG_TEST([modules/libc/tests/pubapi/fildes-pubapi-valgrind-t1.test])
 
 AC_CONFIG_HEADERS(
     [modules/libpthread/include/picotm/config/picotm-libpthread-config.h])
@@ -156,9 +162,15 @@ CONFIG_LIBPTHREAD
 
 AC_CONFIG_HEADERS([modules/libm/include/picotm/config/picotm-libm-config.h])
 CONFIG_LIBM
+CONFIG_TEST([modules/libm/tests/pubapi/complex-pubapi-valgrind-t1.test])
+CONFIG_TEST([modules/libm/tests/pubapi/math-pubapi-valgrind-t1.test])
 
 AC_CONFIG_HEADERS([modules/txlib/include/picotm/config/picotm-txlib-config.h])
 CONFIG_TXLIB
+CONFIG_TEST([modules/txlib/tests/pubapi/txlist-pubapi-valgrind-t1.test])
+CONFIG_TEST([modules/txlib/tests/pubapi/txmultiset-pubapi-valgrind-t1.test])
+CONFIG_TEST([modules/txlib/tests/pubapi/txqueue-pubapi-valgrind-t1.test])
+CONFIG_TEST([modules/txlib/tests/pubapi/txstack-pubapi-valgrind-t1.test])
 
 
 dnl

--- a/m4/config_arithmetic.m4
+++ b/m4/config_arithmetic.m4
@@ -33,8 +33,6 @@ AC_DEFUN([_CONFIG_ARITHMETIC], [
     _CHECK_MODULE_TYPE([arithmetic], [unsigned long],      [[]])
     _CHECK_MODULE_TYPE([arithmetic], [unsigned long long], [[]])
     _CHECK_MODULE_TYPE([arithmetic], [unsigned short],     [[]])
-
-    CONFIG_TEST([modules/arithmetic/tests/pubapi/arithmetic-pubapi-valgrind-t1.test])
 ])
 
 AC_DEFUN([CONFIG_ARITHMETIC], [

--- a/m4/config_arithmetic.m4
+++ b/m4/config_arithmetic.m4
@@ -12,7 +12,7 @@
 #   notice and this notice are preserved.  This file is offered as-is,
 #   without any warranty.
 
-AC_DEFUN([CONFIG_ARITHMETIC], [
+AC_DEFUN([_CONFIG_ARITHMETIC], [
 
     #
     # Types
@@ -35,4 +35,17 @@ AC_DEFUN([CONFIG_ARITHMETIC], [
     _CHECK_MODULE_TYPE([arithmetic], [unsigned short],     [[]])
 
     CONFIG_TEST([modules/arithmetic/tests/pubapi/arithmetic-pubapi-valgrind-t1.test])
+])
+
+AC_DEFUN([CONFIG_ARITHMETIC], [
+    AC_ARG_ENABLE([module-arithmetic],
+                  [AS_HELP_STRING([--enable-module-arithmetic],
+                                  [enable arithmetic module @<:@default=yes@:>@])],
+                  [enable_module_arithmetic=$enableval],
+                  [enable_module_arithmetic=yes])
+    AM_CONDITIONAL([ENABLE_MODULE_ARITHMETIC],
+                   [test "x$enable_module_arithmetic" = "xyes"])
+    AS_VAR_IF([enable_module_arithmetic], [yes], [
+        _CONFIG_ARITHMETIC
+    ])
 ])

--- a/m4/config_cast.m4
+++ b/m4/config_cast.m4
@@ -33,8 +33,6 @@ AC_DEFUN([_CONFIG_CAST], [
     _CHECK_MODULE_TYPE([cast], [unsigned long],      [[]])
     _CHECK_MODULE_TYPE([cast], [unsigned long long], [[]])
     _CHECK_MODULE_TYPE([cast], [unsigned short],     [[]])
-
-    CONFIG_TEST([modules/cast/tests/pubapi/cast-pubapi-valgrind-t1.test])
 ])
 
 AC_DEFUN([CONFIG_CAST], [

--- a/m4/config_cast.m4
+++ b/m4/config_cast.m4
@@ -12,7 +12,7 @@
 #   notice and this notice are preserved.  This file is offered as-is,
 #   without any warranty.
 
-AC_DEFUN([CONFIG_CAST], [
+AC_DEFUN([_CONFIG_CAST], [
 
     #
     # Types
@@ -35,4 +35,17 @@ AC_DEFUN([CONFIG_CAST], [
     _CHECK_MODULE_TYPE([cast], [unsigned short],     [[]])
 
     CONFIG_TEST([modules/cast/tests/pubapi/cast-pubapi-valgrind-t1.test])
+])
+
+AC_DEFUN([CONFIG_CAST], [
+    AC_ARG_ENABLE([module-cast],
+                  [AS_HELP_STRING([--enable-module-cast],
+                                  [enable type-casting module @<:@default=yes@:>@])],
+                  [enable_module_cast=$enableval],
+                  [enable_module_cast=yes])
+    AM_CONDITIONAL([ENABLE_MODULE_CAST],
+                   [test "x$enable_module_cast" = "xyes"])
+    AS_VAR_IF([enable_module_cast], [yes], [
+        _CONFIG_CAST
+    ])
 ])

--- a/m4/config_libc.m4
+++ b/m4/config_libc.m4
@@ -395,10 +395,6 @@ AC_DEFUN([_CONFIG_LIBC], [
         _CHECK_LIBC_SYS_TYPES_H
         _CHECK_LIBC_UNISTD_H
     ])
-
-    CONFIG_TEST([modules/libc/tests/pubapi/allocator-pubapi-valgrind-t1.test])
-    CONFIG_TEST([modules/libc/tests/pubapi/cwd-pubapi-valgrind-t1.test])
-    CONFIG_TEST([modules/libc/tests/pubapi/fildes-pubapi-valgrind-t1.test])
 ])
 
 AC_DEFUN([CONFIG_LIBC], [

--- a/m4/config_libc.m4
+++ b/m4/config_libc.m4
@@ -356,7 +356,7 @@ AC_DEFUN([_CHECK_LIBC_UNISTD_H], [
     ])
 ])
 
-AC_DEFUN([CONFIG_LIBC], [
+AC_DEFUN([_CONFIG_LIBC], [
     dnl Functions from the C standard library are often provided as
     dnl built-ins by the compiler. This breaks the Autoconf test. We
     dnl disable built-ins while testing for longjmp().
@@ -399,4 +399,17 @@ AC_DEFUN([CONFIG_LIBC], [
     CONFIG_TEST([modules/libc/tests/pubapi/allocator-pubapi-valgrind-t1.test])
     CONFIG_TEST([modules/libc/tests/pubapi/cwd-pubapi-valgrind-t1.test])
     CONFIG_TEST([modules/libc/tests/pubapi/fildes-pubapi-valgrind-t1.test])
+])
+
+AC_DEFUN([CONFIG_LIBC], [
+    AC_ARG_ENABLE([module-libc],
+                  [AS_HELP_STRING([--enable-module-libc],
+                                  [enable C Standard Library module @<:@default=yes@:>@])],
+                  [enable_module_libc=$enableval],
+                  [enable_module_libc=yes])
+    AM_CONDITIONAL([ENABLE_MODULE_LIBC],
+                   [test "x$enable_module_libc" = "xyes"])
+    AS_VAR_IF([enable_module_libc], [yes], [
+        _CONFIG_LIBC
+    ])
 ])

--- a/m4/config_libm.m4
+++ b/m4/config_libm.m4
@@ -298,7 +298,7 @@ AC_DEFUN([_CHECK_LIBM_MATH_H], [
     ])
 ])
 
-AC_DEFUN([CONFIG_LIBM], [
+AC_DEFUN([_CONFIG_LIBM], [
     AS_VAR_SET([have_libm], [no])
     AC_CHECK_LIB([m], [signgam])
     AS_VAR_IF([ac_cv_lib_m_signgam], [yes],
@@ -315,4 +315,17 @@ AC_DEFUN([CONFIG_LIBM], [
 
     CONFIG_TEST([modules/libm/tests/pubapi/complex-pubapi-valgrind-t1.test])
     CONFIG_TEST([modules/libm/tests/pubapi/math-pubapi-valgrind-t1.test])
+])
+
+AC_DEFUN([CONFIG_LIBM], [
+    AC_ARG_ENABLE([module-libm],
+                  [AS_HELP_STRING([--enable-module-libm],
+                                  [enable C Standard Math Library module @<:@default=yes@:>@])],
+                  [enable_module_libm=$enableval],
+                  [enable_module_libm=yes])
+    AM_CONDITIONAL([ENABLE_MODULE_LIBM],
+                   [test "x$enable_module_libm" = "xyes"])
+    AS_VAR_IF([enable_module_libm], [yes], [
+        _CONFIG_LIBM
+    ])
 ])

--- a/m4/config_libm.m4
+++ b/m4/config_libm.m4
@@ -312,9 +312,6 @@ AC_DEFUN([_CONFIG_LIBM], [
         _CHECK_LIBM_COMPLEX_H
         _CHECK_LIBM_MATH_H
     ])
-
-    CONFIG_TEST([modules/libm/tests/pubapi/complex-pubapi-valgrind-t1.test])
-    CONFIG_TEST([modules/libm/tests/pubapi/math-pubapi-valgrind-t1.test])
 ])
 
 AC_DEFUN([CONFIG_LIBM], [

--- a/m4/config_libpthread.m4
+++ b/m4/config_libpthread.m4
@@ -31,9 +31,22 @@ AC_DEFUN([_CHECK_LIBPTHREAD_PTHREAD_H], [
     ])
 ])
 
-AC_DEFUN([CONFIG_LIBPTHREAD], [
+AC_DEFUN([_CONFIG_LIBPTHREAD], [
     AC_REQUIRE([AX_PTHREAD])
     AS_VAR_IF([ax_pthread_ok], [yes], [
         _CHECK_LIBPTHREAD_PTHREAD_H
+    ])
+])
+
+AC_DEFUN([CONFIG_LIBPTHREAD], [
+    AC_ARG_ENABLE([module-libpthread],
+                  [AS_HELP_STRING([--enable-module-libpthread],
+                                  [enable POSIX Threads module @<:@default=yes@:>@])],
+                  [enable_module_libpthread=$enableval],
+                  [enable_module_libpthread=yes])
+    AM_CONDITIONAL([ENABLE_MODULE_LIBPTHREAD],
+                   [test "x$enable_module_libpthread" = "xyes"])
+    AS_VAR_IF([enable_module_libpthread], [yes], [
+        _CONFIG_LIBPTHREAD
     ])
 ])

--- a/m4/config_tm.m4
+++ b/m4/config_tm.m4
@@ -33,8 +33,6 @@ AC_DEFUN([_CONFIG_TM], [
     _CHECK_MODULE_TYPE([tm], [unsigned long],      [[]])
     _CHECK_MODULE_TYPE([tm], [unsigned long long], [[]])
     _CHECK_MODULE_TYPE([tm], [unsigned short],     [[]])
-
-    CONFIG_TEST([modules/tm/tests/pubapi/tm-pubapi-valgrind-t1.test])
 ])
 
 AC_DEFUN([CONFIG_TM], [

--- a/m4/config_tm.m4
+++ b/m4/config_tm.m4
@@ -12,7 +12,7 @@
 #   notice and this notice are preserved.  This file is offered as-is,
 #   without any warranty.
 
-AC_DEFUN([CONFIG_TM], [
+AC_DEFUN([_CONFIG_TM], [
 
     #
     # Types
@@ -35,4 +35,17 @@ AC_DEFUN([CONFIG_TM], [
     _CHECK_MODULE_TYPE([tm], [unsigned short],     [[]])
 
     CONFIG_TEST([modules/tm/tests/pubapi/tm-pubapi-valgrind-t1.test])
+])
+
+AC_DEFUN([CONFIG_TM], [
+    AC_ARG_ENABLE([module-tm],
+                  [AS_HELP_STRING([--enable-module-tm],
+                                  [enable Transactional Memory module @<:@default=yes@:>@])],
+                  [enable_module_tm=$enableval],
+                  [enable_module_tm=yes])
+    AM_CONDITIONAL([ENABLE_MODULE_TM],
+                   [test "x$enable_module_tm" = "xyes"])
+    AS_VAR_IF([enable_module_tm], [yes], [
+        _CONFIG_TM
+    ])
 ])

--- a/m4/config_txlib.m4
+++ b/m4/config_txlib.m4
@@ -12,9 +12,22 @@
 #   notice and this notice are preserved.  This file is offered as-is,
 #   without any warranty.
 
-AC_DEFUN([CONFIG_TXLIB], [
+AC_DEFUN([_CONFIG_TXLIB], [
     CONFIG_TEST([modules/txlib/tests/pubapi/txlist-pubapi-valgrind-t1.test])
     CONFIG_TEST([modules/txlib/tests/pubapi/txmultiset-pubapi-valgrind-t1.test])
     CONFIG_TEST([modules/txlib/tests/pubapi/txqueue-pubapi-valgrind-t1.test])
     CONFIG_TEST([modules/txlib/tests/pubapi/txstack-pubapi-valgrind-t1.test])
+])
+
+AC_DEFUN([CONFIG_TXLIB], [
+    AC_ARG_ENABLE([module-txlib],
+                  [AS_HELP_STRING([--enable-module-txlib],
+                                  [enable txlib module @<:@default=yes@:>@])],
+                  [enable_module_txlib=$enableval],
+                  [enable_module_txlib=yes])
+    AM_CONDITIONAL([ENABLE_MODULE_TXLIB],
+                   [test "x$enable_module_txlib" = "xyes"])
+    AS_VAR_IF([enable_module_txlib], [yes], [
+        _CONFIG_TXLIB
+    ])
 ])

--- a/m4/config_txlib.m4
+++ b/m4/config_txlib.m4
@@ -13,10 +13,6 @@
 #   without any warranty.
 
 AC_DEFUN([_CONFIG_TXLIB], [
-    CONFIG_TEST([modules/txlib/tests/pubapi/txlist-pubapi-valgrind-t1.test])
-    CONFIG_TEST([modules/txlib/tests/pubapi/txmultiset-pubapi-valgrind-t1.test])
-    CONFIG_TEST([modules/txlib/tests/pubapi/txqueue-pubapi-valgrind-t1.test])
-    CONFIG_TEST([modules/txlib/tests/pubapi/txstack-pubapi-valgrind-t1.test])
 ])
 
 AC_DEFUN([CONFIG_TXLIB], [

--- a/modules/arithmetic/include/Makefile.am
+++ b/modules/arithmetic/include/Makefile.am
@@ -22,6 +22,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+if ENABLE_MODULE_ARITHMETIC
 nobase_include_HEADERS = picotm/config/picotm-arithmetic-config.h \
                          picotm/picotm-arithmetic.h \
                          picotm/picotm-arithmetic-ctypes.h
+endif

--- a/modules/arithmetic/src/Makefile.am
+++ b/modules/arithmetic/src/Makefile.am
@@ -26,7 +26,10 @@ current = 0
 revision = 0
 age = 0
 
-lib_LTLIBRARIES = libpicotm-arithmetic.la
+lib_LTLIBRARIES =
+if ENABLE_MODULE_ARITHMETIC
+lib_LTLIBRARIES += libpicotm-arithmetic.la
+endif
 
 libpicotm_arithmetic_la_SOURCES = arithmetic.c \
                                   arithmetic.h

--- a/modules/arithmetic/tests/pubapi/Makefile.am
+++ b/modules/arithmetic/tests/pubapi/Makefile.am
@@ -22,21 +22,26 @@
 #
 # SPDX-License-Identifier: MIT
 
-TESTS = arithmetic-pubapi-t1.test \
-        arithmetic-pubapi-t4.test
+PUBAPI_TESTS = arithmetic-pubapi-t1.test \
+               arithmetic-pubapi-t4.test
 
-VALGRIND_TESTS = arithmetic-pubapi-valgrind-t1.test
-
+TESTS =
+if ENABLE_MODULE_ARITHMETIC
+TESTS += $(PUBAPI_TESTS)
 if HAVE_VALGRIND
-TESTS += $(VALGRIND_TESTS)
+TESTS += arithmetic-pubapi-valgrind-t1.test
+endif
 endif
 
-EXTRA_DIST = $(TESTS)
+EXTRA_DIST = $(PUBAPI_TESTS)
 
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(top_srcdir)/build-aux/tap-driver.sh
 
-check_PROGRAMS = arithmetic-pubapi
+check_PROGRAMS =
+if ENABLE_MODULE_ARITHMETIC
+check_PROGRAMS += arithmetic-pubapi
+endif
 
 arithmetic_pubapi_SOURCES = arithmetic_pubapi.c
 

--- a/modules/cast/include/Makefile.am
+++ b/modules/cast/include/Makefile.am
@@ -22,6 +22,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+if ENABLE_MODULE_CAST
 nobase_include_HEADERS = picotm/config/picotm-cast-config.h \
                          picotm/picotm-cast.h \
                          picotm/picotm-cast-ctypes.h
+endif

--- a/modules/cast/src/Makefile.am
+++ b/modules/cast/src/Makefile.am
@@ -26,7 +26,10 @@ current = 0
 revision = 0
 age = 0
 
-lib_LTLIBRARIES = libpicotm-cast.la
+lib_LTLIBRARIES =
+if ENABLE_MODULE_CAST
+lib_LTLIBRARIES += libpicotm-cast.la
+endif
 
 libpicotm_cast_la_SOURCES = cast.c \
 							cast.h

--- a/modules/cast/tests/pubapi/Makefile.am
+++ b/modules/cast/tests/pubapi/Makefile.am
@@ -22,21 +22,26 @@
 #
 # SPDX-License-Identifier: MIT
 
-TESTS = cast-pubapi-t1.test \
-        cast-pubapi-t4.test
+PUBAPI_TESTS = cast-pubapi-t1.test \
+               cast-pubapi-t4.test
 
-VALGRIND_TESTS = cast-pubapi-valgrind-t1.test
-
+TESTS =
+if ENABLE_MODULE_CAST
+TESTS += $(PUBAPI_TESTS)
 if HAVE_VALGRIND
-TESTS += $(VALGRIND_TESTS)
+TESTS += cast-pubapi-valgrind-t1.test
+endif
 endif
 
-EXTRA_DIST = $(TESTS)
+EXTRA_DIST = $(PUBAPI_TESTS)
 
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(top_srcdir)/build-aux/tap-driver.sh
 
-check_PROGRAMS = cast-pubapi
+check_PROGRAMS =
+if ENABLE_MODULE_CAST
+check_PROGRAMS += cast-pubapi
+endif
 
 cast_pubapi_SOURCES = cast_pubapi.c
 

--- a/modules/libc/include/Makefile.am
+++ b/modules/libc/include/Makefile.am
@@ -1,6 +1,6 @@
 #
 # MIT License
-# Copyright (c) 2017    Thomas Zimmermann <tdz@users.sourceforge.net>
+# Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,6 +22,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+if ENABLE_MODULE_LIBC
 nobase_include_HEADERS = picotm/config/picotm-libc-config.h \
                          picotm/errno.h \
                          picotm/fcntl-tm.h \
@@ -44,3 +45,4 @@ nobase_include_HEADERS = picotm/config/picotm-libc-config.h \
                          picotm/picotm-libc.h \
                          picotm/unistd-tm.h \
                          picotm/unistd.h
+endif

--- a/modules/libc/src/Makefile.am
+++ b/modules/libc/src/Makefile.am
@@ -26,7 +26,10 @@ current = 3
 revision = 2
 age = 2
 
-lib_LTLIBRARIES = libpicotm-c.la
+lib_LTLIBRARIES =
+if ENABLE_MODULE_LIBC
+lib_LTLIBRARIES += libpicotm-c.la
+endif
 
 libpicotm_c_la_SOURCES = allocator/allocator_event.c \
                          allocator/allocator_event.h \

--- a/modules/libc/tests/pubapi/Makefile.am
+++ b/modules/libc/tests/pubapi/Makefile.am
@@ -22,29 +22,33 @@
 #
 # SPDX-License-Identifier: MIT
 
-TESTS = allocator-pubapi-t1.test \
-        allocator-pubapi-t4.test \
-        cwd-pubapi-t1.test \
-        cwd-pubapi-t4.test \
-        fildes-pubapi-t1.test \
-        fildes-pubapi-t4.test
+PUBAPI_TESTS = allocator-pubapi-t1.test \
+               allocator-pubapi-t4.test \
+               cwd-pubapi-t1.test \
+               cwd-pubapi-t4.test \
+               fildes-pubapi-t1.test \
+               fildes-pubapi-t4.test
 
-VALGRIND_TESTS = allocator-pubapi-valgrind-t1.test \
-                 cwd-pubapi-valgrind-t1.test \
-                 fildes-pubapi-valgrind-t1.test
-
+TESTS =
+if ENABLE_MODULE_LIBC
+TESTS += $(PUBAPI_TESTS)
 if HAVE_VALGRIND
-TESTS += $(VALGRIND_TESTS)
+TESTS += allocator-pubapi-valgrind-t1.test \
+         cwd-pubapi-valgrind-t1.test \
+         fildes-pubapi-valgrind-t1.test
+endif
 endif
 
-EXTRA_DIST = $(TESTS)
+EXTRA_DIST = $(PUBAPI_TESTS)
 
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(top_srcdir)/build-aux/tap-driver.sh
 
+if ENABLE_MODULE_LIBC
 check_PROGRAMS = allocator-pubapi \
                  cwd-pubapi \
                  fildes-pubapi
+endif
 
 allocator_pubapi_SOURCES = allocator_pubapi.c
 

--- a/modules/libm/include/Makefile.am
+++ b/modules/libm/include/Makefile.am
@@ -1,6 +1,6 @@
 #
 # MIT License
-# Copyright (c) 2017    Thomas Zimmermann <tdz@users.sourceforge.net>
+# Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,8 +22,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+if ENABLE_MODULE_LIBM
 nobase_include_HEADERS = picotm/complex.h \
                          picotm/config/picotm-libm-config.h \
                          picotm/math.h \
                          picotm/math-tm.h \
                          picotm/picotm-libm.h
+endif

--- a/modules/libm/src/Makefile.am
+++ b/modules/libm/src/Makefile.am
@@ -1,6 +1,6 @@
 #
 # MIT License
-# Copyright (c) 2017    Thomas Zimmermann <tdz@users.sourceforge.net>
+# Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,10 @@ current = 0
 revision = 2
 age = 0
 
-lib_LTLIBRARIES = libpicotm-m.la
+lib_LTLIBRARIES =
+if ENABLE_MODULE_LIBM
+lib_LTLIBRARIES += libpicotm-m.la
+endif
 
 libpicotm_m_la_SOURCES = complex.c \
                          fpu_tx.c \

--- a/modules/libm/tests/pubapi/Makefile.am
+++ b/modules/libm/tests/pubapi/Makefile.am
@@ -22,25 +22,29 @@
 #
 # SPDX-License-Identifier: MIT
 
-TESTS = complex-pubapi-t1.test \
-        complex-pubapi-t4.test \
-        math-pubapi-t1.test \
-        math-pubapi-t4.test
+PUBAPI_TESTS = complex-pubapi-t1.test \
+               complex-pubapi-t4.test \
+               math-pubapi-t1.test \
+               math-pubapi-t4.test
 
-VALGRIND_TESTS = complex-pubapi-valgrind-t1.test \
-                 math-pubapi-valgrind-t1.test
-
+TESTS =
+if ENABLE_MODULE_LIBM
+TESTS += $(PUBAPI_TESTS)
 if HAVE_VALGRIND
-TESTS += $(VALGRIND_TESTS)
+TESTS += complex-pubapi-valgrind-t1.test \
+         math-pubapi-valgrind-t1.test
+endif
 endif
 
-EXTRA_DIST = $(TESTS)
+EXTRA_DIST = $(PUBAPI_TESTS)
 
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(top_srcdir)/build-aux/tap-driver.sh
 
+if ENABLE_MODULE_LIBM
 check_PROGRAMS = complex-pubapi \
                  math-pubapi
+endif
 
 complex_pubapi_SOURCES = complex_pubapi.c \
                          testmacro.c \

--- a/modules/libpthread/include/Makefile.am
+++ b/modules/libpthread/include/Makefile.am
@@ -1,6 +1,6 @@
 #
 # MIT License
-# Copyright (c) 2017    Thomas Zimmermann <tdz@users.sourceforge.net>
+# Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,5 +22,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+if ENABLE_MODULE_LIBPTHREAD
 nobase_include_HEADERS = picotm/config/picotm-libpthread-config.h \
                          picotm/pthread.h
+endif

--- a/modules/libpthread/src/Makefile.am
+++ b/modules/libpthread/src/Makefile.am
@@ -1,6 +1,6 @@
 #
 # MIT License
-# Copyright (c) 2017    Thomas Zimmermann <tdz@users.sourceforge.net>
+# Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,10 @@ current = 0
 revision = 0
 age = 0
 
-lib_LTLIBRARIES = libpicotm-pthread.la
+lib_LTLIBRARIES =
+if ENABLE_MODULE_LIBPTHREAD
+lib_LTLIBRARIES += libpicotm-pthread.la
+endif
 
 libpicotm_pthread_la_SOURCES = pthread.c
 

--- a/modules/tm/include/Makefile.am
+++ b/modules/tm/include/Makefile.am
@@ -22,6 +22,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+if ENABLE_MODULE_TM
 nobase_include_HEADERS = picotm/config/picotm-tm-config.h \
                          picotm/picotm-tm.h \
                          picotm/picotm-tm-ctypes.h
+endif

--- a/modules/tm/src/Makefile.am
+++ b/modules/tm/src/Makefile.am
@@ -26,7 +26,10 @@ current = 1
 revision = 1
 age = 0
 
-lib_LTLIBRARIES = libpicotm-tm.la
+lib_LTLIBRARIES =
+if ENABLE_MODULE_TM
+lib_LTLIBRARIES += libpicotm-tm.la
+endif
 
 libpicotm_tm_la_SOURCES = block.h \
                           frame.c \

--- a/modules/tm/tests/pubapi/Makefile.am
+++ b/modules/tm/tests/pubapi/Makefile.am
@@ -22,21 +22,25 @@
 #
 # SPDX-License-Identifier: MIT
 
-TESTS = tm-pubapi-t1.test \
-        tm-pubapi-t4.test
+PUBAPI_TESTS = tm-pubapi-t1.test \
+               tm-pubapi-t4.test
 
-VALGRIND_TESTS = tm-pubapi-valgrind-t1.test
-
+TESTS =
+if ENABLE_MODULE_TM
+TESTS += $(PUBAPI_TESTS)
 if HAVE_VALGRIND
-TESTS += $(VALGRIND_TESTS)
+TESTS += tm-pubapi-valgrind-t1.test
+endif
 endif
 
-EXTRA_DIST = $(TESTS)
+EXTRA_DIST = $(PUBAPI_TESTS)
 
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(top_srcdir)/build-aux/tap-driver.sh
 
+if ENABLE_MODULE_TM
 check_PROGRAMS = tm-pubapi
+endif
 
 tm_pubapi_SOURCES = tm_pubapi.c
 

--- a/modules/txlib/include/Makefile.am
+++ b/modules/txlib/include/Makefile.am
@@ -1,6 +1,6 @@
 #
 # MIT License
-# Copyright (c) 2017    Thomas Zimmermann <tdz@users.sourceforge.net>
+# Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,6 +22,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+if ENABLE_MODULE_TXLIB
 nobase_include_HEADERS = picotm/config/picotm-txlib-config.h \
                          picotm/picotm-txlib.h \
                          picotm/picotm-txlist.h \
@@ -32,3 +33,4 @@ nobase_include_HEADERS = picotm/config/picotm-txlib-config.h \
                          picotm/picotm-txqueue-state.h \
                          picotm/picotm-txstack.h \
                          picotm/picotm-txstack-state.h
+endif

--- a/modules/txlib/src/Makefile.am
+++ b/modules/txlib/src/Makefile.am
@@ -26,7 +26,10 @@ current = 1
 revision = 1
 age = 1
 
-lib_LTLIBRARIES = libpicotm-txlib.la
+lib_LTLIBRARIES =
+if ENABLE_MODULE_TXLIB
+lib_LTLIBRARIES += libpicotm-txlib.la
+endif
 
 libpicotm_txlib_la_SOURCES = txlib_event.c \
                              txlib_event.h \

--- a/modules/txlib/tests/pubapi/Makefile.am
+++ b/modules/txlib/tests/pubapi/Makefile.am
@@ -22,33 +22,37 @@
 #
 # SPDX-License-Identifier: MIT
 
-TESTS = txlist-pubapi-t1.test \
-        txlist-pubapi-t4.test \
-        txmultiset-pubapi-t1.test \
-        txmultiset-pubapi-t4.test \
-        txqueue-pubapi-t1.test \
-        txqueue-pubapi-t4.test \
-        txstack-pubapi-t1.test \
-        txstack-pubapi-t4.test
+PUBAPI_TESTS = txlist-pubapi-t1.test \
+               txlist-pubapi-t4.test \
+               txmultiset-pubapi-t1.test \
+               txmultiset-pubapi-t4.test \
+               txqueue-pubapi-t1.test \
+               txqueue-pubapi-t4.test \
+               txstack-pubapi-t1.test \
+               txstack-pubapi-t4.test
 
-VALGRIND_TESTS = txlist-pubapi-valgrind-t1.test \
-                 txmultiset-pubapi-valgrind-t1.test \
-                 txqueue-pubapi-valgrind-t1.test \
-                 txstack-pubapi-valgrind-t1.test
-
+TESTS =
+if ENABLE_MODULE_TXLIB
+TESTS += $(PUBAPI_TESTS)
 if HAVE_VALGRIND
-TESTS += $(VALGRIND_TESTS)
+TESTS += txlist-pubapi-valgrind-t1.test \
+         txmultiset-pubapi-valgrind-t1.test \
+         txqueue-pubapi-valgrind-t1.test \
+         txstack-pubapi-valgrind-t1.test
+endif
 endif
 
-EXTRA_DIST = $(TESTS)
+EXTRA_DIST = $(PUBAPI_TESTS)
 
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(top_srcdir)/build-aux/tap-driver.sh
 
+if ENABLE_MODULE_TXLIB
 check_PROGRAMS = txlist-pubapi \
                  txmultiset-pubapi \
                  txqueue-pubapi \
                  txstack-pubapi
+endif
 
 txlist_pubapi_SOURCES = txlist_pubapi.c
 


### PR DESCRIPTION
With this patch set, each module can be disabled at compile time. This allows to replace modules with a custom implementation or not build a module that is unsupported by the target system.