### PR TITLE
Force package-local includes

### DIFF
--- a/include/picotm/compiler.h
+++ b/include/picotm/compiler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "picotm/config/picotm-config.h"
+
 /**
  * \ingroup group_modules
  * \file

--- a/include/picotm/picotm-error.h
+++ b/include/picotm/picotm-error.h
@@ -33,10 +33,10 @@
  * \brief Contains struct picotm_error and helper functions.
  */
 
+#include "picotm/config/picotm-config.h"
 #if defined(__MACH__)
 #include <mach/mach.h>
 #endif
-#include <picotm/config/picotm-config.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include "compiler.h"

--- a/include/picotm/picotm-module.h
+++ b/include/picotm/picotm-module.h
@@ -37,6 +37,7 @@
  * All existing modules are written on top of this interface as well.
  */
 
+#include "picotm/config/picotm-config.h"
 #if defined(__MACH__)
 #include <mach/mach.h>
 #endif

--- a/include/picotm/picotm.h
+++ b/include/picotm/picotm.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "picotm/config/picotm-config.h"
 #if defined(__MACH__)
 #include <mach/mach.h>
 #endif
-#include <picotm/config/picotm-config.h>
 #include <setjmp.h>
 #include "compiler.h"
 #include "picotm-error.h"

--- a/modules/arithmetic/include/picotm/picotm-arithmetic-ctypes.h
+++ b/modules/arithmetic/include/picotm/picotm-arithmetic-ctypes.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
+#include "picotm/config/picotm-arithmetic-config.h"
+#include "picotm/compiler.h"
 #include <float.h>
 #include <limits.h>
-#include <picotm/compiler.h>
 #include <stdlib.h>
 #include "picotm-arithmetic.h"
 

--- a/modules/arithmetic/include/picotm/picotm-arithmetic.h
+++ b/modules/arithmetic/include/picotm/picotm-arithmetic.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-arithmetic-config.h>
+#include "picotm/config/picotm-arithmetic-config.h"
+#include "picotm/compiler.h"
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/arithmetic/src/Makefile.am
+++ b/modules/arithmetic/src/Makefile.am
@@ -36,8 +36,8 @@ libpicotm_arithmetic_la_SOURCES = arithmetic.c \
 
 libpicotm_arithmetic_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
-AM_CPPFLAGS = -I$(top_builddir)/modules/arithmetic/include \
-              -I$(top_srcdir)/modules/arithmetic/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/modules/arithmetic/include \
+              -iquote $(top_srcdir)/modules/arithmetic/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/arithmetic/src/arithmetic.c
+++ b/modules/arithmetic/src/arithmetic.c
@@ -24,8 +24,8 @@
  */
 
 #include "arithmetic.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
 
 static void
 report_errno(int errno_code)

--- a/modules/arithmetic/tests/pubapi/Makefile.am
+++ b/modules/arithmetic/tests/pubapi/Makefile.am
@@ -56,14 +56,14 @@ LDADD = $(top_builddir)/tests/libtests/libpicotm_tests.la \
         $(top_builddir)/modules/arithmetic/src/libpicotm-arithmetic.la \
         $(top_builddir)/src/libpicotm.la
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
-              -I$(top_srcdir)/tests/libtests \
-              -I$(top_builddir)/tests/libsafeblk \
-              -I$(top_srcdir)/tests/libsafeblk \
-              -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
-              -I$(top_builddir)/modules/arithmetic/include \
-              -I$(top_srcdir)/modules/arithmetic/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtests \
+              -iquote $(top_srcdir)/tests/libtests \
+              -iquote $(top_builddir)/tests/libsafeblk \
+              -iquote $(top_srcdir)/tests/libsafeblk \
+              -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
+              -iquote $(top_builddir)/modules/arithmetic/include \
+              -iquote $(top_srcdir)/modules/arithmetic/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/arithmetic/tests/pubapi/arithmetic_pubapi.c
+++ b/modules/arithmetic/tests/pubapi/arithmetic_pubapi.c
@@ -23,10 +23,10 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-arithmetic-ctypes.h"
 #include <errno.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-arithmetic-ctypes.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include "ptr.h"

--- a/modules/cast/include/picotm/picotm-cast-ctypes.h
+++ b/modules/cast/include/picotm/picotm-cast-ctypes.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
+#include "picotm/config/picotm-cast-config.h"
+#include "picotm/compiler.h"
 #include <float.h>
 #include <limits.h>
-#include <picotm/compiler.h>
 #include "picotm-cast.h"
 
 PICOTM_BEGIN_DECLS

--- a/modules/cast/include/picotm/picotm-cast.h
+++ b/modules/cast/include/picotm/picotm-cast.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-cast-config.h>
+#include "picotm/config/picotm-cast-config.h"
+#include "picotm/compiler.h"
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/cast/src/Makefile.am
+++ b/modules/cast/src/Makefile.am
@@ -36,8 +36,8 @@ libpicotm_cast_la_SOURCES = cast.c \
 
 libpicotm_cast_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
-AM_CPPFLAGS = -I$(top_builddir)/modules/cast/include \
-              -I$(top_srcdir)/modules/cast/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/modules/cast/include \
+              -iquote $(top_srcdir)/modules/cast/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/cast/src/cast.c
+++ b/modules/cast/src/cast.c
@@ -24,8 +24,8 @@
  */
 
 #include "cast.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
 
 static void
 report_errno(int errno_code)

--- a/modules/cast/tests/pubapi/Makefile.am
+++ b/modules/cast/tests/pubapi/Makefile.am
@@ -56,14 +56,14 @@ LDADD = $(top_builddir)/tests/libtests/libpicotm_tests.la \
         $(top_builddir)/modules/cast/src/libpicotm-cast.la \
         $(top_builddir)/src/libpicotm.la
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
-              -I$(top_srcdir)/tests/libtests \
-              -I$(top_builddir)/tests/libsafeblk \
-              -I$(top_srcdir)/tests/libsafeblk \
-              -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
-              -I$(top_builddir)/modules/cast/include \
-              -I$(top_srcdir)/modules/cast/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtests \
+              -iquote $(top_srcdir)/tests/libtests \
+              -iquote $(top_builddir)/tests/libsafeblk \
+              -iquote $(top_srcdir)/tests/libsafeblk \
+              -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
+              -iquote $(top_builddir)/modules/cast/include \
+              -iquote $(top_srcdir)/modules/cast/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/cast/tests/pubapi/cast_pubapi.c
+++ b/modules/cast/tests/pubapi/cast_pubapi.c
@@ -23,10 +23,10 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "picotm/picotm.h"
+#include "picotm/picotm-cast-ctypes.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-cast-ctypes.h>
-#include <picotm/picotm-module.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include "ptr.h"

--- a/modules/libc/include/picotm/errno.h
+++ b/modules/libc/include/picotm/errno.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <errno.h>
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/libc/include/picotm/fcntl-tm.h
+++ b/modules/libc/include/picotm/fcntl-tm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <fcntl.h>
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/libc/include/picotm/fcntl.h
+++ b/modules/libc/include/picotm/fcntl.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <fcntl.h>
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/libc/include/picotm/picotm-libc.h
+++ b/modules/libc/include/picotm/picotm-libc.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/libc/include/picotm/sched.h
+++ b/modules/libc/include/picotm/sched.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <sched.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/stdbool.h
+++ b/modules/libc/include/picotm/stdbool.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
-#include <picotm/picotm-tm.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-tm.h"
 #include <stdbool.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/stddef.h
+++ b/modules/libc/include/picotm/stddef.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,9 @@
 
 #pragma once
 
-#include <picotm/config/picotm-libc-config.h>
-#include <picotm/picotm-tm.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-tm.h"
 #include <stddef.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/stdint.h
+++ b/modules/libc/include/picotm/stdint.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
-#include <picotm/picotm-tm.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-tm.h"
 #include <stdint.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/stdio-tm.h
+++ b/modules/libc/include/picotm/stdio-tm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <stdarg.h>
 #include <stdio.h>
 

--- a/modules/libc/include/picotm/stdio.h
+++ b/modules/libc/include/picotm/stdio.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <stdarg.h>
 #include <stdio.h>
 

--- a/modules/libc/include/picotm/stdlib-tm.h
+++ b/modules/libc/include/picotm/stdlib-tm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <stdlib.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/stdlib.h
+++ b/modules/libc/include/picotm/stdlib.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
-#include <picotm/picotm-tm.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-tm.h"
 #include <stdlib.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/string-tm.h
+++ b/modules/libc/include/picotm/string-tm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <string.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/string.h
+++ b/modules/libc/include/picotm/string.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <string.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/sys/socket-tm.h
+++ b/modules/libc/include/picotm/sys/socket-tm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <sys/socket.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/sys/socket.h
+++ b/modules/libc/include/picotm/sys/socket.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <sys/socket.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/sys/stat-tm.h
+++ b/modules/libc/include/picotm/sys/stat-tm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <sys/stat.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/sys/stat.h
+++ b/modules/libc/include/picotm/sys/stat.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <sys/stat.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/sys/types.h
+++ b/modules/libc/include/picotm/sys/types.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,9 @@
 
 #pragma once
 
-#include <picotm/config/picotm-libc-config.h>
-#include <picotm/picotm-tm.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-tm.h"
 #include <sys/types.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/unistd-tm.h
+++ b/modules/libc/include/picotm/unistd-tm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <unistd.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/include/picotm/unistd.h
+++ b/modules/libc/include/picotm/unistd.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libc-config.h>
+#include "picotm/config/picotm-libc-config.h"
+#include "picotm/compiler.h"
 #include <unistd.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libc/src/Makefile.am
+++ b/modules/libc/src/Makefile.am
@@ -176,10 +176,10 @@ libpicotm_c_la_SOURCES = allocator/allocator_event.c \
 
 libpicotm_c_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
-AM_CPPFLAGS = -I$(top_builddir)/modules/libc/include \
-              -I$(top_srcdir)/modules/libc/include \
-              -I$(top_builddir)/modules/tm/include \
-              -I$(top_srcdir)/modules/tm/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/modules/libc/include \
+              -iquote $(top_srcdir)/modules/libc/include \
+              -iquote $(top_builddir)/modules/tm/include \
+              -iquote $(top_srcdir)/modules/tm/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/libc/src/allocator/allocator_log.c
+++ b/modules/libc/src/allocator/allocator_log.c
@@ -24,10 +24,10 @@
  */
 
 #include "allocator_log.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 
 void
 allocator_log_init(struct allocator_log* self, unsigned long module)

--- a/modules/libc/src/allocator/allocator_tx.c
+++ b/modules/libc/src/allocator/allocator_tx.c
@@ -24,9 +24,9 @@
  */
 
 #include "allocator_tx.h"
+#include "picotm/picotm-error.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
 #include <stdlib.h>
 #include "allocator_log.h"
 

--- a/modules/libc/src/allocator/module.c
+++ b/modules/libc/src/allocator/module.c
@@ -24,9 +24,9 @@
  */
 
 #include "module.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
 #include <stdbool.h>
-#include <picotm/picotm-module.h>
 #include "allocator_log.h"
 #include "allocator_tx.h"
 

--- a/modules/libc/src/cwd/cwd.c
+++ b/modules/libc/src/cwd/cwd.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,10 +24,10 @@
  */
 
 #include "cwd.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-rwstate.h>
 
 static void
 init_rwlocks(struct picotm_rwlock* beg, const struct picotm_rwlock* end)

--- a/modules/libc/src/cwd/cwd.h
+++ b/modules/libc/src/cwd/cwd.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
+#include "picotm/picotm-lib-rwlock.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_cwd

--- a/modules/libc/src/cwd/cwd.h
+++ b/modules/libc/src/cwd/cwd.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <picotm/picotm-lib-rwlock.h>
-#include "cwd.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_cwd

--- a/modules/libc/src/cwd/cwd_log.c
+++ b/modules/libc/src/cwd/cwd_log.c
@@ -24,10 +24,10 @@
  */
 
 #include "cwd_log.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 
 void
 cwd_log_init(struct cwd_log* self, unsigned long module)

--- a/modules/libc/src/cwd/cwd_tx.c
+++ b/modules/libc/src/cwd/cwd_tx.c
@@ -24,12 +24,12 @@
  */
 
 #include "cwd_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include "compat/get_current_dir_name.h"

--- a/modules/libc/src/cwd/cwd_tx.h
+++ b/modules/libc/src/cwd/cwd_tx.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-rwstate.h"
 #include <stddef.h>
 #include <stdint.h>
 #include "cwd.h"

--- a/modules/libc/src/cwd/module.c
+++ b/modules/libc/src/cwd/module.c
@@ -24,10 +24,10 @@
  */
 
 #include "module.h"
+#include "picotm/picotm-lib-spinlock.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-lib-spinlock.h>
-#include <picotm/picotm-module.h>
 #include <stdatomic.h>
 #include <stdlib.h>
 #include "cwd.h"

--- a/modules/libc/src/error/module.c
+++ b/modules/libc/src/error/module.c
@@ -24,8 +24,8 @@
  */
 
 #include "module.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-module.h>
 #include <stdlib.h>
 #include "error_tx.h"
 

--- a/modules/libc/src/fcntl-tm.c
+++ b/modules/libc/src/fcntl-tm.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "picotm/fcntl-tm.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-module.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>

--- a/modules/libc/src/fcntl.c
+++ b/modules/libc/src/fcntl.c
@@ -24,10 +24,10 @@
  */
 
 #include "picotm/fcntl.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-tm.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-tm.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>

--- a/modules/libc/src/fildes/chrdev.c
+++ b/modules/libc/src/fildes/chrdev.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "chrdev.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-rwstate.h>
 #include <stdlib.h>
 
 static struct chrdev*

--- a/modules/libc/src/fildes/chrdev.h
+++ b/modules/libc/src/fildes/chrdev.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-shared-ref-obj.h>
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-shared-ref-obj.h"
 #include "fileid.h"
 
 /**

--- a/modules/libc/src/fildes/chrdev_tx.c
+++ b/modules/libc/src/fildes/chrdev_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,13 +24,13 @@
  */
 
 #include "chrdev_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-tab.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/modules/libc/src/fildes/chrdev_tx.h
+++ b/modules/libc/src/fildes/chrdev_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-ref.h>
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-ref.h"
+#include "picotm/picotm-lib-rwstate.h"
+#include "picotm/picotm-libc.h"
 #include <sys/types.h>
 #include "chrdev.h"
 #include "file_tx.h"
-#include "picotm/picotm-libc.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_fd

--- a/modules/libc/src/fildes/chrdevtab.c
+++ b/modules/libc/src/fildes/chrdevtab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "chrdevtab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 #include <pthread.h>
 #include "chrdev.h"
 #include "range.h"

--- a/modules/libc/src/fildes/dir.c
+++ b/modules/libc/src/fildes/dir.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "dir.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-rwstate.h>
 #include <stdlib.h>
 
 static struct dir*

--- a/modules/libc/src/fildes/dir.h
+++ b/modules/libc/src/fildes/dir.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-shared-ref-obj.h>
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-shared-ref-obj.h"
 #include "fileid.h"
 
 /**

--- a/modules/libc/src/fildes/dir_tx.c
+++ b/modules/libc/src/fildes/dir_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,13 +24,13 @@
  */
 
 #include "dir_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-tab.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/modules/libc/src/fildes/dir_tx.h
+++ b/modules/libc/src/fildes/dir_tx.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-ref.h>
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-ref.h"
+#include "picotm/picotm-lib-rwstate.h"
+#include "picotm/picotm-libc.h"
 #include <sys/types.h>
 #include "dir.h"
 #include "file_tx.h"
-#include "picotm/picotm-libc.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_fd

--- a/modules/libc/src/fildes/dirtab.c
+++ b/modules/libc/src/fildes/dirtab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "dirtab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 #include <pthread.h>
 #include "dir.h"
 #include "range.h"

--- a/modules/libc/src/fildes/fchmodoptab.c
+++ b/modules/libc/src/fildes/fchmodoptab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "fchmodoptab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
 #include "fchmodop.h"
 
 unsigned long

--- a/modules/libc/src/fildes/fcntloptab.c
+++ b/modules/libc/src/fildes/fcntloptab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "fcntloptab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
 #include "fcntlop.h"
 
 unsigned long

--- a/modules/libc/src/fildes/fd.c
+++ b/modules/libc/src/fildes/fd.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,13 +24,13 @@
  */
 
 #include "fd.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-rwstate.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include "compat/temp_failure_retry.h"

--- a/modules/libc/src/fildes/fd.h
+++ b/modules/libc/src/fildes/fd.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-shared-ref-obj.h>
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-shared-ref-obj.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_fd

--- a/modules/libc/src/fildes/fd_tx.c
+++ b/modules/libc/src/fildes/fd_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,10 +24,10 @@
  */
 
 #include "fd_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/modules/libc/src/fildes/fd_tx.h
+++ b/modules/libc/src/fildes/fd_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,9 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-ref.h>
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-ref.h"
+#include "picotm/picotm-lib-rwstate.h"
+#include "picotm/picotm-libc.h"
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -34,7 +35,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include "fd.h"
-#include "picotm/picotm-libc.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_fd

--- a/modules/libc/src/fildes/fdtab.c
+++ b/modules/libc/src/fildes/fdtab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "fdtab.h"
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-rwstate.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-rwstate.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <pthread.h>
 #include "fd.h"
 

--- a/modules/libc/src/fildes/fdtab_tx.c
+++ b/modules/libc/src/fildes/fdtab_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "fdtab_tx.h"
+#include "picotm/picotm-error.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
 #include "fdtab.h"
 
 void

--- a/modules/libc/src/fildes/fdtab_tx.h
+++ b/modules/libc/src/fildes/fdtab_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-rwstate.h"
 #include <stdbool.h>
 
 struct picotm_error;

--- a/modules/libc/src/fildes/fifo.c
+++ b/modules/libc/src/fildes/fifo.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "fifo.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-rwstate.h>
 #include <stdlib.h>
 
 static struct fifo*

--- a/modules/libc/src/fildes/fifo.h
+++ b/modules/libc/src/fildes/fifo.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-shared-ref-obj.h>
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-shared-ref-obj.h"
 #include "fileid.h"
 
 /**

--- a/modules/libc/src/fildes/fifo_tx.c
+++ b/modules/libc/src/fildes/fifo_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,13 +24,13 @@
  */
 
 #include "fifo_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-tab.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/modules/libc/src/fildes/fifo_tx.h
+++ b/modules/libc/src/fildes/fifo_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-ref.h>
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-ref.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <sys/types.h>
 #include "fifo.h"
 #include "file_tx.h"

--- a/modules/libc/src/fildes/fifotab.c
+++ b/modules/libc/src/fildes/fifotab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "fifotab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 #include <pthread.h>
 #include "fifo.h"
 #include "range.h"

--- a/modules/libc/src/fildes/fildes_log.c
+++ b/modules/libc/src/fildes/fildes_log.c
@@ -24,10 +24,10 @@
  */
 
 #include "fildes_log.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 
 void
 fildes_log_init(struct fildes_log* self, unsigned long module)

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -24,11 +24,11 @@
  */
 
 #include "fildes_tx.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/modules/libc/src/fildes/fildes_tx.h
+++ b/modules/libc/src/fildes/fildes_tx.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-error.h>
+#include "picotm/picotm-error.h"
 #include <sys/queue.h>
 #include <sys/time.h>
 #include "chrdev_tx.h"

--- a/modules/libc/src/fildes/file_tx_ops.c
+++ b/modules/libc/src/fildes/file_tx_ops.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "file_tx_ops.h"
+#include "picotm/picotm-error.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
 
 int
 file_tx_op_accept_exec_enotsock(struct file_tx* base, struct ofd_tx* ofd_tx,

--- a/modules/libc/src/fildes/fileid.c
+++ b/modules/libc/src/fildes/fileid.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "fileid.h"
+#include "picotm/picotm-error.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
 #include <sys/stat.h>
 
 void

--- a/modules/libc/src/fildes/iooptab.c
+++ b/modules/libc/src/fildes/iooptab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "iooptab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
 #include "range.h"
 #include "ioop.h"
 

--- a/modules/libc/src/fildes/module.c
+++ b/modules/libc/src/fildes/module.c
@@ -24,9 +24,9 @@
  */
 
 #include "module.h"
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
 #include <stdlib.h>
 #include "fildes_event.h"
 #include "fildes_log.h"

--- a/modules/libc/src/fildes/ofd.c
+++ b/modules/libc/src/fildes/ofd.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "ofd.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-rwstate.h>
 #include <stdlib.h>
 #include <unistd.h>
 

--- a/modules/libc/src/fildes/ofd.h
+++ b/modules/libc/src/fildes/ofd.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-shared-ref-obj.h>
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-shared-ref-obj.h"
 #include <stdbool.h>
 #include <sys/types.h>
 #include "ofd_id.h"

--- a/modules/libc/src/fildes/ofd_id.c
+++ b/modules/libc/src/fildes/ofd_id.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "ofd_id.h"
+#include "picotm/picotm-error.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
 #include <sys/stat.h>
 
 static void

--- a/modules/libc/src/fildes/ofd_tx.c
+++ b/modules/libc/src/fildes/ofd_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,10 +24,10 @@
  */
 
 #include "ofd_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
 #include <string.h>
 #include <unistd.h>
 #include "file_tx.h"

--- a/modules/libc/src/fildes/ofd_tx.h
+++ b/modules/libc/src/fildes/ofd_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-ref.h>
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-ref.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <sys/queue.h>
 #include "ofd.h"
 

--- a/modules/libc/src/fildes/ofdtab.c
+++ b/modules/libc/src/fildes/ofdtab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "ofdtab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 #include <pthread.h>
 #include <string.h>
 #include "range.h"

--- a/modules/libc/src/fildes/openoptab.c
+++ b/modules/libc/src/fildes/openoptab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,10 +24,10 @@
  */
 
 #include "openoptab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
 #include <stdlib.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
 #include "openop.h"
 
 unsigned long

--- a/modules/libc/src/fildes/pipeoptab.c
+++ b/modules/libc/src/fildes/pipeoptab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "pipeoptab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
 #include "pipeop.h"
 
 unsigned long

--- a/modules/libc/src/fildes/regfile.c
+++ b/modules/libc/src/fildes/regfile.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "regfile.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-rwstate.h>
 #include "rwcountermap.h"
 
 #define RECSIZE (1ul << RECBITS)

--- a/modules/libc/src/fildes/regfile.h
+++ b/modules/libc/src/fildes/regfile.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-shared-ref-obj.h>
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-shared-ref-obj.h"
 #include "fileid.h"
 #include "rwlockmap.h"
 

--- a/modules/libc/src/fildes/regfile_tx.c
+++ b/modules/libc/src/fildes/regfile_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "regfile_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-tab.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/modules/libc/src/fildes/regfile_tx.h
+++ b/modules/libc/src/fildes/regfile_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-ref.h>
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-ref.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <sys/types.h>
 #include "file_tx.h"
 #include "picotm/picotm-libc.h"

--- a/modules/libc/src/fildes/regfiletab.c
+++ b/modules/libc/src/fildes/regfiletab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "regfiletab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 #include <pthread.h>
 #include "range.h"
 #include "regfile.h"

--- a/modules/libc/src/fildes/regiontab.c
+++ b/modules/libc/src/fildes/regiontab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "regiontab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
 #include <stdlib.h>
 #include "region.h"
 

--- a/modules/libc/src/fildes/rwcounter.c
+++ b/modules/libc/src/fildes/rwcounter.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "rwcounter.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-rwlock.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-rwlock.h>
 #include <stdbool.h>
 
 enum {

--- a/modules/libc/src/fildes/rwcountermap.c
+++ b/modules/libc/src/fildes/rwcountermap.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "rwcountermap.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-module.h>
 #include <stdlib.h>
 #include "range.h"
 #include "rwcounter.h"

--- a/modules/libc/src/fildes/rwcountermap.h
+++ b/modules/libc/src/fildes/rwcountermap.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-treemap.h>
+#include "picotm/picotm-lib-treemap.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_fd

--- a/modules/libc/src/fildes/rwlockmap.c
+++ b/modules/libc/src/fildes/rwlockmap.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "rwlockmap.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
 #include <stdlib.h>
 #include <sys/types.h>
 

--- a/modules/libc/src/fildes/rwlockmap.h
+++ b/modules/libc/src/fildes/rwlockmap.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-shared-treemap.h>
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-shared-treemap.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_fd

--- a/modules/libc/src/fildes/seekoptab.c
+++ b/modules/libc/src/fildes/seekoptab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "seekoptab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-tab.h>
 #include "seekop.h"
 
 unsigned long

--- a/modules/libc/src/fildes/socket.c
+++ b/modules/libc/src/fildes/socket.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "socket.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-rwstate.h>
 #include <stdlib.h>
 
 static struct socket*

--- a/modules/libc/src/fildes/socket.h
+++ b/modules/libc/src/fildes/socket.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
-#include <picotm/picotm-lib-shared-ref-obj.h>
+#include "picotm/picotm-lib-rwlock.h"
+#include "picotm/picotm-lib-shared-ref-obj.h"
 #include "fileid.h"
 
 /**

--- a/modules/libc/src/fildes/socket_tx.c
+++ b/modules/libc/src/fildes/socket_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "socket_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-tab.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-lib-tab.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/modules/libc/src/fildes/socket_tx.h
+++ b/modules/libc/src/fildes/socket_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-ref.h>
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-ref.h"
+#include "picotm/picotm-lib-rwstate.h"
+#include "picotm/picotm-libc.h"
 #include <sys/socket.h>
 #include <sys/types.h>
 #include "file_tx.h"
-#include "picotm/picotm-libc.h"
 #include "socket.h"
 
 /**

--- a/modules/libc/src/fildes/sockettab.c
+++ b/modules/libc/src/fildes/sockettab.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,11 +24,11 @@
  */
 
 #include "sockettab.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 #include <pthread.h>
 #include "range.h"
 #include "socket.h"

--- a/modules/libc/src/sched.c
+++ b/modules/libc/src/sched.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "picotm/sched.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
 #include "error/module.h"
 
 #if defined(PICOTM_LIBC_HAVE_SCHED_YIELD) && PICOTM_LIBC_HAVE_SCHED_YIELD

--- a/modules/libc/src/stdio-tm.c
+++ b/modules/libc/src/stdio-tm.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "picotm/stdio-tm.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
 #include "error/module.h"
 
 #if defined(PICOTM_LIBC_HAVE_SNPRINTF) && PICOTM_LIBC_HAVE_SNPRINTF

--- a/modules/libc/src/stdio.c
+++ b/modules/libc/src/stdio.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "picotm/stdio.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-tm.h"
+#include "picotm/stdio-tm.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-tm.h>
 #include <string.h>
 #include "error/module.h"
-#include "picotm/stdio-tm.h"
 
 #if defined(PICOTM_LIBC_HAVE_SNPRINTF) && PICOTM_LIBC_HAVE_SNPRINTF
 PICOTM_EXPORT

--- a/modules/libc/src/stdlib-tm.c
+++ b/modules/libc/src/stdlib-tm.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@
  */
 
 #include "picotm/stdlib-tm.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm.h"
 #include <errno.h>
 /* We test and include <malloc_np.h> first, because FreeBSD provides
  * <malloc_np.h>, but fails with an error if <malloc.h> is included.
@@ -33,8 +35,6 @@
 #elif defined (HAVE_MALLOC_H) && HAVE_MALLOC_H
 #include <malloc.h>
 #endif
-#include <picotm/picotm-module.h>
-#include <picotm/picotm.h>
 #include <string.h>
 #include "allocator/module.h"
 #include "compat/malloc_usable_size.h"

--- a/modules/libc/src/stdlib.c
+++ b/modules/libc/src/stdlib.c
@@ -24,6 +24,8 @@
  */
 
 #include "picotm/stdlib.h"
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
 /* We test and include <malloc_np.h> first, because FreeBSD provides
  * <malloc_np.h>, but fails with an error if <malloc.h> is included.
@@ -33,8 +35,6 @@
 #elif defined (HAVE_MALLOC_H) && HAVE_MALLOC_H
 #include <malloc.h>
 #endif
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
 #include <string.h>
 #include "allocator/module.h"
 #include "compat/malloc_usable_size.h"

--- a/modules/libc/src/string-tm.c
+++ b/modules/libc/src/string-tm.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "picotm/string-tm.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
 #include "allocator/module.h"
 #include "error/module.h"
 

--- a/modules/libc/src/string.c
+++ b/modules/libc/src/string.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "picotm/string.h"
-#include <errno.h>
-#include <stdbool.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-tm.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-tm.h"
 #include "picotm/stdlib.h"
 #include "picotm/string-tm.h"
+#include <errno.h>
+#include <stdbool.h>
 
 /*
  * Memory functions

--- a/modules/libc/src/sys_socket-tm.c
+++ b/modules/libc/src/sys_socket-tm.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "picotm/sys/socket-tm.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
 #include "error/module.h"
 #include "fildes/module.h"
 

--- a/modules/libc/src/sys_socket.c
+++ b/modules/libc/src/sys_socket.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "picotm/sys/socket.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-tm.h"
+#include "picotm/sys/socket-tm.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-tm.h>
 #include "error/module.h"
 #include "fildes/module.h"
-#include "picotm/sys/socket-tm.h"
 
 #if defined(PICOTM_LIBC_HAVE_ACCEPT) && PICOTM_LIBC_HAVE_ACCEPT
 PICOTM_EXPORT

--- a/modules/libc/src/sys_stat-tm.c
+++ b/modules/libc/src/sys_stat-tm.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "picotm/sys/stat.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
 #include "error/module.h"
 #include "fildes/module.h"
 

--- a/modules/libc/src/sys_stat.c
+++ b/modules/libc/src/sys_stat.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "picotm/sys/stat.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-tm.h"
+#include "picotm/sys/stat-tm.h"
 #include <errno.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-tm.h>
 #include "error/module.h"
 #include "fildes/module.h"
-#include "picotm/sys/stat-tm.h"
 
 #if defined(PICOTM_LIBC_HAVE_CHMOD) && PICOTM_LIBC_HAVE_CHMOD
 PICOTM_EXPORT

--- a/modules/libc/src/unistd-tm.c
+++ b/modules/libc/src/unistd-tm.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "picotm/unistd-tm.h"
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
 #include "cwd/module.h"
 #include "error/module.h"
 #include "fildes/module.h"

--- a/modules/libc/src/unistd.c
+++ b/modules/libc/src/unistd.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,13 +24,13 @@
  */
 
 #include "picotm/unistd.h"
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-tm.h"
+#include "picotm/unistd-tm.h"
 #include <errno.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-tm.h>
 #include "error/module.h"
 #include "fildes/module.h"
-#include "picotm/unistd-tm.h"
 
 #if defined(PICOTM_LIBC_HAVE__EXIT) && PICOTM_LIBC_HAVE__EXIT
 PICOTM_EXPORT

--- a/modules/libc/tests/pubapi/Makefile.am
+++ b/modules/libc/tests/pubapi/Makefile.am
@@ -68,16 +68,16 @@ LDADD = $(top_builddir)/tests/libtests/libpicotm_tests.la \
         $(top_builddir)/modules/tm/src/libpicotm-tm.la \
         $(top_builddir)/src/libpicotm.la
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
-              -I$(top_srcdir)/tests/libtests \
-              -I$(top_builddir)/tests/libsafeblk \
-              -I$(top_srcdir)/tests/libsafeblk \
-              -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
-              -I$(top_builddir)/modules/libc/include \
-              -I$(top_srcdir)/modules/libc/include \
-              -I$(top_builddir)/modules/tm/include \
-              -I$(top_srcdir)/modules/tm/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtests \
+              -iquote $(top_srcdir)/tests/libtests \
+              -iquote $(top_builddir)/tests/libsafeblk \
+              -iquote $(top_srcdir)/tests/libsafeblk \
+              -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
+              -iquote $(top_builddir)/modules/libc/include \
+              -iquote $(top_srcdir)/modules/libc/include \
+              -iquote $(top_builddir)/modules/tm/include \
+              -iquote $(top_srcdir)/modules/tm/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/libc/tests/pubapi/allocator_pubapi.c
+++ b/modules/libc/tests/pubapi/allocator_pubapi.c
@@ -23,11 +23,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <picotm/stddef.h>
-#include <picotm/stdlib.h>
-#include <picotm/stdlib-tm.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-tm-ctypes.h>
+#include "picotm/stddef.h"
+#include "picotm/stdlib.h"
+#include "picotm/stdlib-tm.h"
+#include "picotm/picotm.h"
+#include "picotm/picotm-tm-ctypes.h"
 #include "ptr.h"
 #include "safe_stdlib.h"
 #include "test.h"

--- a/modules/libc/tests/pubapi/cwd_pubapi.c
+++ b/modules/libc/tests/pubapi/cwd_pubapi.c
@@ -23,15 +23,15 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-tm.h"
+#include "picotm/sched.h"
+#include "picotm/stdio-tm.h"
+#include "picotm/stdlib.h"
+#include "picotm/unistd.h"
+#include "picotm/unistd-tm.h"
 #include <limits.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-tm.h>
-#include <picotm/sched.h>
-#include <picotm/stdio-tm.h>
-#include <picotm/stdlib.h>
-#include <picotm/unistd.h>
-#include <picotm/unistd-tm.h>
 #include <string.h>
 #include "ptr.h"
 #include "safeblk.h"

--- a/modules/libc/tests/pubapi/fildes_pubapi.c
+++ b/modules/libc/tests/pubapi/fildes_pubapi.c
@@ -23,22 +23,22 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "picotm/fcntl.h"
+#include "picotm/stddef.h"
+#include "picotm/stdlib.h"
+#include "picotm/string.h"
+#include "picotm/string-tm.h"
+#include "picotm/sys/types.h"
+#include "picotm/picotm.h"
+#include "picotm/picotm-libc.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-tm-ctypes.h"
+#include "picotm/unistd.h"
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <picotm/fcntl.h>
-#include <picotm/stddef.h>
-#include <picotm/stdlib.h>
-#include <picotm/string.h>
-#include <picotm/string-tm.h>
-#include <picotm/sys/types.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-libc.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-tm-ctypes.h>
-#include <picotm/unistd.h>
 #include "ptr.h"
 #include "safe_fcntl.h"
 #include "safe_pthread.h"

--- a/modules/libm/include/picotm/complex.h
+++ b/modules/libm/include/picotm/complex.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "picotm/config/picotm-libm-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-tm.h"
 #include <complex.h>
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libm-config.h>
-#include <picotm/picotm-tm.h>
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/libm/include/picotm/math-tm.h
+++ b/modules/libm/include/picotm/math-tm.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "picotm/config/picotm-libm-config.h"
+#include "picotm/compiler.h"
 #include <math.h>
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libm-config.h>
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/libm/include/picotm/math.h
+++ b/modules/libm/include/picotm/math.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "picotm/config/picotm-libm-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-tm.h"
 #include <math.h>
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libm-config.h>
-#include <picotm/picotm-tm.h>
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/libm/include/picotm/picotm-libm.h
+++ b/modules/libm/include/picotm/picotm-libm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libm-config.h>
+#include "picotm/config/picotm-libm-config.h"
+#include "picotm/compiler.h"
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/libm/src/Makefile.am
+++ b/modules/libm/src/Makefile.am
@@ -44,12 +44,12 @@ libpicotm_m_la_SOURCES = complex.c \
 
 libpicotm_m_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
-AM_CPPFLAGS = -I$(top_builddir)/modules/libm/include \
-              -I$(top_srcdir)/modules/libm/include \
-              -I$(top_builddir)/modules/libc/include \
-              -I$(top_srcdir)/modules/libc/include \
-              -I$(top_builddir)/modules/tm/include \
-              -I$(top_srcdir)/modules/tm/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/modules/libm/include \
+              -iquote $(top_srcdir)/modules/libm/include \
+              -iquote $(top_builddir)/modules/libc/include \
+              -iquote $(top_srcdir)/modules/libc/include \
+              -iquote $(top_builddir)/modules/tm/include \
+              -iquote $(top_srcdir)/modules/tm/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/libm/src/fpu_tx.c
+++ b/modules/libm/src/fpu_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "fpu_tx.h"
+#include "picotm/picotm-error.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
 
 /**
  * \todo Access to floating-point environment and status flags is

--- a/modules/libm/src/libm.c
+++ b/modules/libm/src/libm.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
  */
 
 #include "picotm/picotm-libm.h"
-#include <picotm/picotm-module.h>
+#include "picotm/picotm-module.h"
 #include "module.h"
 
 PICOTM_EXPORT

--- a/modules/libm/src/math.c
+++ b/modules/libm/src/math.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,12 +24,12 @@
  */
 
 #include "picotm/math.h"
+#include "picotm/picotm-tm-ctypes.h"
+#include "picotm/picotm-libc.h"
+#include "picotm/math-tm.h"
 #include <fenv.h>
 #include <math.h>
-#include <picotm/picotm-tm-ctypes.h>
-#include <picotm/picotm-libc.h>
 #include "matherr.h"
-#include "picotm/math-tm.h"
 
 #if defined(PICOTM_LIBM_HAVE_ACOS) && PICOTM_LIBM_HAVE_ACOS
 PICOTM_EXPORT

--- a/modules/libm/src/matherr.c
+++ b/modules/libm/src/matherr.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "err.h"
+#include "matherr.h"
 #include <errno.h>
 #include <fenv.h>
 #include <math.h>

--- a/modules/libm/src/matherr.c
+++ b/modules/libm/src/matherr.c
@@ -24,11 +24,11 @@
  */
 
 #include "matherr.h"
+#include "picotm/picotm-libc.h"
+#include "picotm/picotm-module.h"
 #include <errno.h>
 #include <fenv.h>
 #include <math.h>
-#include <picotm/picotm-libc.h>
-#include <picotm/picotm-module.h>
 #include "module.h"
 
 /* Gcc does not support the FENV_ACCESS pragma. */

--- a/modules/libm/src/module.c
+++ b/modules/libm/src/module.c
@@ -24,8 +24,8 @@
  */
 
 #include "picotm/picotm-libc.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-module.h>
 #include <stdlib.h>
 #include "fpu_tx.h"
 

--- a/modules/libm/tests/pubapi/Makefile.am
+++ b/modules/libm/tests/pubapi/Makefile.am
@@ -67,18 +67,18 @@ LDADD = $(top_builddir)/tests/libtests/libpicotm_tests.la \
         $(top_builddir)/modules/tm/src/libpicotm-tm.la \
         $(top_builddir)/src/libpicotm.la
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
-              -I$(top_srcdir)/tests/libtests \
-              -I$(top_builddir)/tests/libsafeblk \
-              -I$(top_srcdir)/tests/libsafeblk \
-              -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
-              -I$(top_builddir)/modules/libm/include \
-              -I$(top_srcdir)/modules/libm/include \
-              -I$(top_builddir)/modules/libc/include \
-              -I$(top_srcdir)/modules/libc/include \
-              -I$(top_builddir)/modules/tm/include \
-              -I$(top_srcdir)/modules/tm/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtests \
+              -iquote $(top_srcdir)/tests/libtests \
+              -iquote $(top_builddir)/tests/libsafeblk \
+              -iquote $(top_srcdir)/tests/libsafeblk \
+              -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
+              -iquote $(top_builddir)/modules/libm/include \
+              -iquote $(top_srcdir)/modules/libm/include \
+              -iquote $(top_builddir)/modules/libc/include \
+              -iquote $(top_srcdir)/modules/libc/include \
+              -iquote $(top_builddir)/modules/tm/include \
+              -iquote $(top_srcdir)/modules/tm/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/libm/tests/pubapi/complex_pubapi.c
+++ b/modules/libm/tests/pubapi/complex_pubapi.c
@@ -23,9 +23,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "picotm/complex.h"
+#include "picotm/picotm-tm.h"
 #include <math.h>
-#include <picotm/complex.h>
-#include <picotm/picotm-tm.h>
 #include "ptr.h"
 #include "test.h"
 #include "testhlp.h"

--- a/modules/libm/tests/pubapi/math_pubapi.c
+++ b/modules/libm/tests/pubapi/math_pubapi.c
@@ -23,11 +23,11 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "picotm/math.h"
+#include "picotm/picotm-tm.h"
 #include <errno.h>
 #include <fenv.h>
 #include <float.h>
-#include <picotm/math.h>
-#include <picotm/picotm-tm.h>
 #include <stdbool.h>
 #include "ptr.h"
 #include "sysenv.h"

--- a/modules/libm/tests/pubapi/testmacro.h
+++ b/modules/libm/tests/pubapi/testmacro.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
-#include <safeblk.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
+#include "safeblk.h"
 #include "taputils.h"
 
 #define __TEST_SYMBOL(_func)    \

--- a/modules/libpthread/include/picotm/pthread.h
+++ b/modules/libpthread/include/picotm/pthread.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-libpthread-config.h>
-#include <picotm/picotm-tm.h>
+#include "picotm/config/picotm-libpthread-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-tm.h"
 #include <pthread.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/libpthread/src/Makefile.am
+++ b/modules/libpthread/src/Makefile.am
@@ -35,10 +35,10 @@ libpicotm_pthread_la_SOURCES = pthread.c
 
 libpicotm_pthread_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
-AM_CPPFLAGS = -I$(top_builddir)/modules/libpthread/include \
-              -I$(top_srcdir)/modules/libpthread/include \
-              -I$(top_builddir)/modules/tm/include \
-              -I$(top_srcdir)/modules/tm/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/modules/libpthread/include \
+              -iquote $(top_srcdir)/modules/libpthread/include \
+              -iquote $(top_builddir)/modules/tm/include \
+              -iquote $(top_srcdir)/modules/tm/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/tm/include/picotm/picotm-tm-ctypes.h
+++ b/modules/tm/include/picotm/picotm-tm-ctypes.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-tm-config.h>
+#include "picotm/config/picotm-tm-config.h"
+#include "picotm/compiler.h"
 #include "picotm-tm.h"
 
 PICOTM_BEGIN_DECLS

--- a/modules/tm/include/picotm/picotm-tm.h
+++ b/modules/tm/include/picotm/picotm-tm.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-tm-config.h>
+#include "picotm/config/picotm-tm-config.h"
+#include "picotm/compiler.h"
 #include <stddef.h>
 #include <stdint.h>
 

--- a/modules/tm/src/Makefile.am
+++ b/modules/tm/src/Makefile.am
@@ -49,8 +49,8 @@ libpicotm_tm_la_SOURCES = block.h \
 
 libpicotm_tm_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
-AM_CPPFLAGS = -I$(top_builddir)/modules/tm/include \
-              -I$(top_srcdir)/modules/tm/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/modules/tm/include \
+              -iquote $(top_srcdir)/modules/tm/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/tm/src/frame.c
+++ b/modules/tm/src/frame.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,9 +24,9 @@
  */
 
 #include "frame.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-rwstate.h"
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-rwstate.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include "block.h"

--- a/modules/tm/src/frame.h
+++ b/modules/tm/src/frame.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwlock.h>
+#include "picotm/picotm-lib-rwlock.h"
 #include <stdatomic.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/modules/tm/src/framemap.c
+++ b/modules/tm/src/framemap.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,10 +24,10 @@
  */
 
 #include "framemap.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
 #include <assert.h>
 #include <limits.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
 #include <stdlib.h>
 #include "block.h"
 #include "frame.h"

--- a/modules/tm/src/framemap.h
+++ b/modules/tm/src/framemap.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-shared-treemap.h>
+#include "picotm/picotm-lib-shared-treemap.h"
 
 /**
  * \cond impl || tm_impl

--- a/modules/tm/src/module.c
+++ b/modules/tm/src/module.c
@@ -24,10 +24,10 @@
  */
 
 #include "module.h"
+#include "picotm/picotm-lib-spinlock.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-lib-spinlock.h>
-#include <picotm/picotm-module.h>
 #include <stdatomic.h>
 #include <stdlib.h>
 #include "vmem.h"

--- a/modules/tm/src/page.c
+++ b/modules/tm/src/page.c
@@ -24,8 +24,8 @@
  */
 
 #include "page.h"
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
 #include <string.h>
 #include "frame.h"
 #include "vmem.h"

--- a/modules/tm/src/page.h
+++ b/modules/tm/src/page.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-rwstate.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/queue.h>

--- a/modules/tm/src/vmem.c
+++ b/modules/tm/src/vmem.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
  */
 
 #include "vmem.h"
-#include <picotm/picotm-module.h>
+#include "picotm/picotm-module.h"
 #include "block.h"
 #include "frame.h"
 

--- a/modules/tm/src/vmem_tx.c
+++ b/modules/tm/src/vmem_tx.c
@@ -24,11 +24,11 @@
  */
 
 #include "vmem_tx.h"
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-ptr.h>
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-tm.h"
 #include <stdlib.h>
 #include <string.h>
-#include "picotm/picotm-tm.h"
 #include "page.h"
 
 void

--- a/modules/tm/tests/pubapi/Makefile.am
+++ b/modules/tm/tests/pubapi/Makefile.am
@@ -55,14 +55,14 @@ LDADD = $(top_builddir)/tests/libtests/libpicotm_tests.la \
         $(top_builddir)/modules/tm/src/libpicotm-tm.la \
         $(top_builddir)/src/libpicotm.la
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
-              -I$(top_srcdir)/tests/libtests \
-              -I$(top_builddir)/tests/libsafeblk \
-              -I$(top_srcdir)/tests/libsafeblk \
-              -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
-              -I$(top_builddir)/modules/tm/include \
-              -I$(top_srcdir)/modules/tm/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtests \
+              -iquote $(top_srcdir)/tests/libtests \
+              -iquote $(top_builddir)/tests/libsafeblk \
+              -iquote $(top_srcdir)/tests/libsafeblk \
+              -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
+              -iquote $(top_builddir)/modules/tm/include \
+              -iquote $(top_srcdir)/modules/tm/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/tm/tests/pubapi/tm_pubapi.c
+++ b/modules/tm/tests/pubapi/tm_pubapi.c
@@ -23,11 +23,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <picotm/picotm.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-module.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-tm-ctypes.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-tm-ctypes.h"
 #include <stdlib.h>
 #include <string.h>
 #include "ptr.h"

--- a/modules/txlib/include/picotm/picotm-txlib.h
+++ b/modules/txlib/include/picotm/picotm-txlib.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/config/picotm-txlib-config.h>
+#include "picotm/config/picotm-txlib-config.h"
 #include "picotm-txlist.h"
 #include "picotm-txlist-state.h"
 #include "picotm-txqueue.h"

--- a/modules/txlib/include/picotm/picotm-txlist-state.h
+++ b/modules/txlib/include/picotm/picotm-txlist-state.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-txlib-config.h>
-#include <picotm/picotm-lib-rwlock.h>
+#include "picotm/config/picotm-txlib-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-lib-rwlock.h"
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/txlib/include/picotm/picotm-txlist.h
+++ b/modules/txlib/include/picotm/picotm-txlist.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-txlib-config.h>
+#include "picotm/compiler.h"
+#include "picotm/config/picotm-txlib-config.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include "picotm-txlist-state.h"

--- a/modules/txlib/include/picotm/picotm-txmultiset-state.h
+++ b/modules/txlib/include/picotm/picotm-txmultiset-state.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-txlib-config.h>
-#include <picotm/picotm-lib-rwlock.h>
+#include "picotm/config/picotm-txlib-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-lib-rwlock.h"
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/txlib/include/picotm/picotm-txmultiset.h
+++ b/modules/txlib/include/picotm/picotm-txmultiset.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-txlib-config.h>
+#include "picotm/config/picotm-txlib-config.h"
+#include "picotm/compiler.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include "picotm-txmultiset-state.h"

--- a/modules/txlib/include/picotm/picotm-txqueue-state.h
+++ b/modules/txlib/include/picotm/picotm-txqueue-state.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "picotm/config/picotm-txlib-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-lib-rwlock.h"
 #include <stddef.h>
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-txlib-config.h>
-#include <picotm/picotm-lib-rwlock.h>
 
 PICOTM_BEGIN_DECLS
 

--- a/modules/txlib/include/picotm/picotm-txqueue.h
+++ b/modules/txlib/include/picotm/picotm-txqueue.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-txlib-config.h>
+#include "picotm/config/picotm-txlib-config.h"
+#include "picotm/compiler.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include "picotm-txqueue-state.h"

--- a/modules/txlib/include/picotm/picotm-txstack-state.h
+++ b/modules/txlib/include/picotm/picotm-txstack-state.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-txlib-config.h>
-#include <picotm/picotm-lib-rwlock.h>
+#include "picotm/config/picotm-txlib-config.h"
+#include "picotm/compiler.h"
+#include "picotm/picotm-lib-rwlock.h"
 #include <stddef.h>
 
 PICOTM_BEGIN_DECLS

--- a/modules/txlib/include/picotm/picotm-txstack.h
+++ b/modules/txlib/include/picotm/picotm-txstack.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <picotm/compiler.h>
-#include <picotm/config/picotm-txlib-config.h>
+#include "picotm/config/picotm-txlib-config.h"
+#include "picotm/compiler.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include "picotm-txstack-state.h"

--- a/modules/txlib/src/Makefile.am
+++ b/modules/txlib/src/Makefile.am
@@ -72,8 +72,8 @@ libpicotm_txlib_la_SOURCES = txlib_event.c \
 
 libpicotm_txlib_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
-AM_CPPFLAGS = -I$(top_builddir)/modules/txlib/include \
-              -I$(top_srcdir)/modules/txlib/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/modules/txlib/include \
+              -iquote $(top_srcdir)/modules/txlib/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/txlib/src/txlib_module.c
+++ b/modules/txlib/src/txlib_module.c
@@ -24,10 +24,10 @@
  */
 
 #include "txlib_module.h"
+#include "picotm/picotm-lib-spinlock.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-lib-spinlock.h>
-#include <picotm/picotm-module.h>
 #include <stdatomic.h>
 #include <stdlib.h>
 #include "txlib_tx.h"

--- a/modules/txlib/src/txlib_tx.c
+++ b/modules/txlib/src/txlib_tx.c
@@ -24,12 +24,12 @@
  */
 
 #include "txlib_tx.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-tab.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
 #include <errno.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-tab.h>
-#include <picotm/picotm-module.h>
 #include <stdlib.h>
 #include <string.h>
 #include "txlib_event.h"

--- a/modules/txlib/src/txlist_tx.c
+++ b/modules/txlib/src/txlist_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "txlist_tx.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-module.h>
 #include "txlist_entry.h"
 #include "txlist_state.h"
 #include "txlib_event.h"

--- a/modules/txlib/src/txlist_tx.h
+++ b/modules/txlib/src/txlist_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-rwstate.h"
 #include <stddef.h>
 #include <stdbool.h>
 

--- a/modules/txlib/src/txmultiset_tx.c
+++ b/modules/txlib/src/txmultiset_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "txmultiset_tx.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-module.h>
 #include "txmultiset_entry.h"
 #include "txmultiset_state.h"
 #include "txlib_event.h"

--- a/modules/txlib/src/txmultiset_tx.h
+++ b/modules/txlib/src/txmultiset_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-rwstate.h"
 #include <stddef.h>
 #include <stdbool.h>
 

--- a/modules/txlib/src/txqueue_tx.c
+++ b/modules/txlib/src/txqueue_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "txqueue_tx.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-module.h>
 #include "txqueue_state.h"
 #include "txlib_event.h"
 #include "txlib_tx.h"

--- a/modules/txlib/src/txqueue_tx.h
+++ b/modules/txlib/src/txqueue_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-rwstate.h"
 #include "txqueue_entry.h"
 
 /**

--- a/modules/txlib/src/txstack_tx.c
+++ b/modules/txlib/src/txstack_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "txstack_tx.h"
+#include "picotm/picotm-module.h"
 #include <assert.h>
-#include <picotm/picotm-module.h>
 #include "txstack_state.h"
 #include "txlib_event.h"
 #include "txlib_tx.h"

--- a/modules/txlib/src/txstack_tx.h
+++ b/modules/txlib/src/txstack_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <picotm/picotm-lib-rwstate.h>
+#include "picotm/picotm-lib-rwstate.h"
 #include "txstack_entry.h"
 
 /**

--- a/modules/txlib/tests/pubapi/Makefile.am
+++ b/modules/txlib/tests/pubapi/Makefile.am
@@ -73,14 +73,14 @@ LDADD = $(top_builddir)/tests/libtests/libpicotm_tests.la \
         $(top_builddir)/modules/txlib/src/libpicotm-txlib.la \
         $(top_builddir)/src/libpicotm.la
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
-              -I$(top_srcdir)/tests/libtests \
-              -I$(top_builddir)/tests/libsafeblk \
-              -I$(top_srcdir)/tests/libsafeblk \
-              -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
-              -I$(top_builddir)/modules/txlib/include \
-              -I$(top_srcdir)/modules/txlib/include \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtests \
+              -iquote $(top_srcdir)/tests/libtests \
+              -iquote $(top_builddir)/tests/libsafeblk \
+              -iquote $(top_srcdir)/tests/libsafeblk \
+              -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
+              -iquote $(top_builddir)/modules/txlib/include \
+              -iquote $(top_srcdir)/modules/txlib/include \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/modules/txlib/tests/pubapi/txlist_pubapi.c
+++ b/modules/txlib/tests/pubapi/txlist_pubapi.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,14 +23,14 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <picotm/picotm.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-module.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-txlist.h"
 #include <stdlib.h>
 #include <string.h>
-#include "picotm/picotm-txlist.h"
 #include "ptr.h"
 #include "safeblk.h"
 #include "safe_sched.h"

--- a/modules/txlib/tests/pubapi/txmultiset_pubapi.c
+++ b/modules/txlib/tests/pubapi/txmultiset_pubapi.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,16 +23,16 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "picotm/picotm.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-txmultiset.h"
 #include <assert.h>
-#include <picotm/picotm.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-module.h>
 #include <stdlib.h>
 #include <string.h>
 #include "compat/static_assert.h"
-#include "picotm/picotm-txmultiset.h"
 #include "ptr.h"
 #include "safeblk.h"
 #include "safe_sched.h"

--- a/modules/txlib/tests/pubapi/txqueue_pubapi.c
+++ b/modules/txlib/tests/pubapi/txqueue_pubapi.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,14 +23,14 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <picotm/picotm.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-module.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-txqueue.h"
 #include <stdlib.h>
 #include <string.h>
-#include "picotm/picotm-txqueue.h"
 #include "ptr.h"
 #include "safeblk.h"
 #include "safe_sched.h"

--- a/modules/txlib/tests/pubapi/txstack_pubapi.c
+++ b/modules/txlib/tests/pubapi/txstack_pubapi.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,14 +23,14 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <picotm/picotm.h>
-#include <picotm/picotm-error.h>
-#include <picotm/picotm-lib-array.h>
-#include <picotm/picotm-lib-ptr.h>
-#include <picotm/picotm-module.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-array.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-module.h"
+#include "picotm/picotm-txstack.h"
 #include <stdlib.h>
 #include <string.h>
-#include "picotm/picotm-txstack.h"
 #include "ptr.h"
 #include "safeblk.h"
 #include "safe_sched.h"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,6 +63,6 @@ libpicotm_la_SOURCES = picotm.c \
 
 libpicotm_la_LDFLAGS = -version-info $(current):$(revision):$(age)
 
-AM_CPPFLAGS = -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/src/picotm.c
+++ b/src/picotm.c
@@ -24,15 +24,15 @@
  */
 
 #include "picotm.h"
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-shared-ref-obj.h"
+#include "picotm/picotm-lib-spinlock.h"
 #include <assert.h>
 #include <errno.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-#include "picotm/picotm-lib-ptr.h"
-#include "picotm/picotm-lib-shared-ref-obj.h"
-#include "picotm/picotm-lib-spinlock.h"
 #include "picotm_lock_manager.h"
 #include "picotm_tx.h"
 

--- a/src/picotm.h
+++ b/src/picotm.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -32,8 +32,8 @@
  * \endcond
  */
 
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
 
 /**
  * \cond impl || lib_impl

--- a/src/picotm_event.c
+++ b/src/picotm_event.c
@@ -24,7 +24,7 @@
  */
 
 #include "picotm_event.h"
-#include <picotm/picotm-error.h>
+#include "picotm/picotm-error.h"
 
 void
 picotm_events_foreach1(struct picotm_event* beg,

--- a/src/picotm_log.c
+++ b/src/picotm_log.c
@@ -24,8 +24,8 @@
  */
 
 #include "picotm_log.h"
+#include "picotm/picotm-error.h"
 #include <assert.h>
-#include <picotm/picotm-error.h>
 #include <string.h>
 #include "picotm_event.h"
 #include "table.h"

--- a/tests/libsafeblk/Makefile.am
+++ b/tests/libsafeblk/Makefile.am
@@ -1,6 +1,6 @@
 #
 # MIT License
-# Copyright (c) 2017    Thomas Zimmermann <tdz@users.sourceforge.net>
+# Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -47,6 +47,6 @@ libpicotm_safeblk_la_SOURCES = compat/pthread_barrier.c \
                                safe_unistd.c \
                                safe_unistd.h
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
               -include config.h

--- a/tests/libtap/Makefile.am
+++ b/tests/libtap/Makefile.am
@@ -1,6 +1,6 @@
 #
 # MIT License
-# Copyright (c) 2017    Thomas Zimmermann <tdz@users.sourceforge.net>
+# Copyright (c) 2017-2018   Thomas Zimmermann <tdz@users.sourceforge.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,6 +29,6 @@ libpicotm_tap_la_SOURCES = tap.c \
                            taputils.c \
                            taputils.h
 
-AM_CPPFLAGS = -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/tests/libtests/Makefile.am
+++ b/tests/libtests/Makefile.am
@@ -40,10 +40,10 @@ libpicotm_tests_la_SOURCES = opts.c \
                              thread.c \
                              thread.h
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
-              -I$(top_builddir)/tests/libsafeblk \
-              -I$(top_srcdir)/tests/libsafeblk \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
+              -iquote $(top_builddir)/tests/libsafeblk \
+              -iquote $(top_srcdir)/tests/libsafeblk \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/tests/libtests/testhlp.c
+++ b/tests/libtests/testhlp.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,8 @@
  */
 
 #include "testhlp.h"
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
 #include <sched.h>
 #include <string.h>
 #include "safeblk.h"

--- a/tests/libtests/thread.c
+++ b/tests/libtests/thread.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
  */
 
 #include "thread.h"
-#include <picotm/picotm.h>
+#include "picotm/picotm.h"
 #include <stdbool.h>
 #include "safeblk.h"
 #include "safe_pthread.h"

--- a/tests/pubapi/Makefile.am
+++ b/tests/pubapi/Makefile.am
@@ -47,12 +47,12 @@ LDADD = $(top_builddir)/tests/libtests/libpicotm_tests.la \
         $(top_builddir)/tests/libtap/libpicotm_tap.la \
         $(top_builddir)/src/libpicotm.la
 
-AM_CPPFLAGS = -I$(top_builddir)/tests/libtests \
-              -I$(top_srcdir)/tests/libtests \
-              -I$(top_builddir)/tests/libsafeblk \
-              -I$(top_srcdir)/tests/libsafeblk \
-              -I$(top_builddir)/tests/libtap \
-              -I$(top_srcdir)/tests/libtap \
-              -I$(top_builddir)/include \
-              -I$(top_srcdir)/include \
+AM_CPPFLAGS = -iquote $(top_builddir)/tests/libtests \
+              -iquote $(top_srcdir)/tests/libtests \
+              -iquote $(top_builddir)/tests/libsafeblk \
+              -iquote $(top_srcdir)/tests/libsafeblk \
+              -iquote $(top_builddir)/tests/libtap \
+              -iquote $(top_srcdir)/tests/libtap \
+              -iquote $(top_builddir)/include \
+              -iquote $(top_srcdir)/include \
               -include config.h

--- a/tests/pubapi/core_pubapi.c
+++ b/tests/pubapi/core_pubapi.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,8 +23,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <picotm/picotm.h>
-#include <picotm/picotm-module.h>
+#include "picotm/picotm.h"
+#include "picotm/picotm-module.h"
 #include <string.h>
 #include "ptr.h"
 #include "safeblk.h"


### PR DESCRIPTION
This patch set changes all include statements to prefer package-local header files over installed header files. The original code might have mixed up both in some situations.