### PR TITLE
Recoverable errors in Cast and Arithmetic module

### DIFF
--- a/modules/arithmetic/src/arithmetic.c
+++ b/modules/arithmetic/src/arithmetic.c
@@ -32,7 +32,6 @@ report_errno(int errno_code)
 {
     struct picotm_error error = PICOTM_ERROR_INITIALIZER;
     picotm_error_set_errno(&error, errno_code);
-    picotm_error_mark_as_non_recoverable(&error);
     picotm_recover_from_error(&error);
 }
 

--- a/modules/cast/src/cast.c
+++ b/modules/cast/src/cast.c
@@ -32,7 +32,6 @@ report_errno(int errno_code)
 {
     struct picotm_error error = PICOTM_ERROR_INITIALIZER;
     picotm_error_set_errno(&error, errno_code);
-    picotm_error_mark_as_non_recoverable(&error);
     picotm_recover_from_error(&error);
 }
 


### PR DESCRIPTION
There's no reason why errors in the cast and arithmetic modules have to be non-recoverable. This patch changes them to *recoverable.* Applications can still decide to treat them otherwise if required.