### PR TITLE
Provide singly-linked list in lib

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -33,6 +33,7 @@ nobase_include_HEADERS = picotm/compiler.h \
                          picotm/picotm-lib-rwstate.h \
                          picotm/picotm-lib-shared-treemap.h \
                          picotm/picotm-lib-shared-ref-obj.h \
+                         picotm/picotm-lib-slist.h \
                          picotm/picotm-lib-spinlock.h \
                          picotm/picotm-lib-tab.h \
                          picotm/picotm-lib-treemap.h \

--- a/include/picotm/picotm-lib-slist.h
+++ b/include/picotm/picotm-lib-slist.h
@@ -1,0 +1,763 @@
+/*
+ * MIT License
+ * Copyright (c) 2018   Thomas Zimmermann <tdz@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "compiler.h"
+#include <stddef.h>
+
+/**
+ * \ingroup group_lib
+ * \file
+ *
+ * \brief Contains `struct picotm_slist` and helpers.
+ *
+ * The data structure `struct picotm_slist` represents a singly-linked
+ * list, or *slist.* This can either be the list head, or an entry in a
+ * list.
+ *
+ * The head of a singly-linked list is the main reference to a list. It
+ * does not itself contain data. A call to `picotm_slist_init_head()`
+ * initializes a list head.
+ *
+ * ~~~{.c}
+ *  struct picotm_slist head;
+ *  picotm_slist_init_head(&head);
+ * ~~~
+ *
+ * Or alternatively, the C pre-processor macro `PICOTM_SLIST_HEAD_INITIALIZER`
+ * initializes static or stack-allocated list heads.
+ *
+ * ~~~{.c}
+ *  static struct picotm_slist head = PICOTM_SLIST_HEAD_INITIALIZER;
+ * ~~~
+ *
+ * Calls to `picotm_slist_init_item()` or `PICOTM_SLIST_ITEM_INITIALIZER`
+ * initialize list entries in a similar way.
+ *
+ * ~~~{.c}
+ *  struct picotm_slist item;
+ *  picotm_slist_init_item(&item);
+ * ~~~
+ *
+ * ~~~{.c}
+ *  static struct picotm_slist item = PICOTM_SLIST_ITEM_INITIALIZER;
+ * ~~~
+ *
+ * Typically, slist items are stored in a container structure that also
+ * holds additional application data. For example, a singly-linked list
+ * that stores values of type `unsigned long` could use the following
+ * data entries.
+ *
+ * ~~~{.c}
+ *  struct ulong_item {
+ *      struct picotm_slist item;   // slist element
+ *      unsigned long       value;  // data value
+ *  };
+ *
+ *  struct ulong_item*
+ *  ulong_item_of_slist(struct picotm_slist* slist)
+ *  {
+        return picotm_containerof(item, struct ulong_item, slist);
+ *  }
+ * ~~~
+ *
+ * The singly-linked list refers from `item` to `item` field of the contained
+ * list entries. The helper function `ulong_item_of_slist()` takes a list item
+ * and returns the corresponding data element of type `struct ulong_item`.
+ *
+ * Both, slist head and item elements, require cleanup by their respective
+ * clean-up function `picotm_slist_uninit_head()` or
+ * `picotm_slist_uninit_item()`.
+ *
+ * ~~~{.c}
+ *  picotm_slist_uninit_item(&item);
+ *  picotm_slist_uninit_head(&head);
+ * ~~~
+ *
+ * List item elements that are to be uninitialized may not be enqueued in a
+ * list; head elements may not refer to any items.
+ *
+ * The functions `picotm_slist_enqueue_front()` and
+ * `picotm_slist_enqueue_back` insert an entry at the front, resp. the back,
+ * of an slist. If we already know an existing entry from an slist, we can
+ * insert an entry before or after the existing one with a call to
+ * `picotm_enqueue_slist_before()`, resp. `picotm_slist_enqueue_after()`.
+ * Here's an example with `picotm_slist_enqueue_front()`.
+ *
+ * ~~~{.c}
+ *  picotm_slist_enqueue_front(&head, &item);
+ * ~~~
+ *
+ * A call to `picotm_slist_dequeue()` removes an entry from an slist.
+ *
+ * ~~~{.c}
+ *  picotm_slist_dequeue(&item);
+ * ~~~
+ *
+ * To see if an item is enqueued in an slist, we call
+ * `picotm_slist_is_enqueued()`, whch returns `true` in this case. Likewise,
+ * a call to `picotm_slist_empty()` returns `true` if a list is empty.
+ *
+ * ~~~{.c}
+ *  bool is_enqueued = picotm_slist_is_enqueued(&item); // is in an slist
+ *
+ *  bool is_empty = picotm_slist_empty(&head); // no items in the slist
+ * ~~~
+ *
+ * For iterating over a singly-linked list, the functions
+ * `picotm_slist_begin()` and `picotm_slist_end()` return the slist's first
+ * and final element. The final element is a terminator and not a useable
+ * slist item. Reaching this value signals the callers to stop iterating.
+ * We use `picotm_slist_next()` and `picotm_slist_prev()` for moving between
+ * consecutive elements. singly-linked lists can only be traversed in forward
+ * direction, so the latter function `picotm_slist_prev()` is of linear
+ * complexity. I should be avoided within loop constructs.
+ *
+ * Here's a typical example of a loop that walks over all elements in an
+ * slist. In this case, it sums up the values of type `unsigned long` that
+ * are enqueued in the list.
+ *
+ * ~~~{.c}
+ *  unsigned long long sum = 0;
+ *
+ *        struct picotm_slist* beg = picotm_slist_begin(&head);
+ *  const struct picotm_slist* end = picotm_slist_end(&head);
+ *
+ *  while (beg != end) {
+ *      const struct ulong_item* ulong = ulong_item_of_slist(beg);
+ *
+ *      sum += ulong->value;
+ *
+ *      beg = picotm_slist_next(beg);
+ *  }
+ *
+ *  // do something with 'sum'
+ * ~~~
+ *
+ * Singly-linked lists provide a number of built-in algorithms. With the
+ * *walk* function `picotm_slist_walk_1()` we can walk over all entries in
+ * a list. With *walk,* the previous example can be rewritten in the
+ * following way.
+ *
+ * ~~~{.c}
+ *  size_t
+ *  sum_cb(struct picotm_slist* item, void* data)
+ *  {
+ *      const struct ulong_item* ulong = ulong_item_of_slist(item);
+ *      unsigned long long* sum = data;
+ *
+ *      *sum += ulong->value;
+ *
+ *      return 1;
+ *  }
+ *
+ *  unsigned long long sum = 0;
+ *  picotm_slist_walk_1(head, sum_cb, &sum); // call sum_cb() for each item
+ *
+ *  // do something with 'sum'
+ * ~~~
+ *
+ * The overall iteration over the slist entries is performed by
+ * `picotm_slist_walk_1()`. The function calls `sum_cb()` for each item
+ * and the pointer to `sum` is passed as additional data parameter.
+ *
+ * The function `sum_cb()` accumulates the list entries' values in
+ * `sum` and returns the number of items to increment. Returning values
+ * larger than *1* therefore allows to skip successive list entries.
+ * Returning *0* prematurely stops the iteration. The value returned
+ * by `picotm_slist_walk1()` is the element at which the iteration stopped.
+ *
+ * With the *find* function `picotm_slist_find_1()` we can search an slist
+ * for the first item that matches a specific criteria. In the following
+ * example, we search for the first element with a value of *0.*
+ *
+ * ~~~{.c}
+ *  _Bool
+ *  test_cb(struct picotm_slist* item, void* data)
+ *  {
+ *      const struct ulong_item* ulong = ulong_item_of_slist(item);
+ *      const unsigned long* value = data;
+ *
+ *      return ulong->value = value; // return 'true' if values match
+ *  }
+ *
+ *  unsigned long value = 0;
+ *  struct picotm_slist* pos = picotm_slist_find_1(&head, test_cb, &value);
+ *  if (pos == picotm_slist_end(&head)) {
+ *      // value not found in list; bail out.
+ *  }
+ *
+ *  // so something with 'pos'
+ * ~~~
+ *
+ * The function `test_cb()` compares the value of an slist item to a
+ * reference value, which is *0* in our case. If both match, it will return
+ * 'true'. The function `picotm_slist_find1()` calls `test_cb()` for each
+ * item in the slist and returns the first item for which the test function
+ * returned 'true'. If none is found, the find function returns the final
+ * terminator entry. Our example code checks and handles this case explicitly.
+ *
+ * Finally, there's the *clean-up* function `picotm_slist_cleanup_0()`, which
+ * dequeues all list entries one by one and calls a clean-up function on
+ * each. Once called, the clean-up function acquires ownership of the given
+ * item. Here's an example of cleaning up a list of items that have been
+ * allocated with `malloc()`. The corresponding `free()` is performed in the
+ * item clean-up function.
+ *
+ * ~~~{.c}
+ *  void
+ *  cleanup_cb(struct picotm_slist* item)
+ *  {
+ *      struct ulong_item* ulong = ulong_item_of_slist(item);
+ *      free(ulong);
+ *  }
+ *
+ *  picotm_slist_cleanup_0(&head, cleanup_cb);
+ * ~~~
+ */
+
+PICOTM_BEGIN_DECLS
+
+/**
+ * \ingroup group_lib
+ * \brief Entry in a singly-linked list.
+ */
+struct picotm_slist {
+    struct picotm_slist* next;
+};
+
+/**
+ * \ingroup group_lib
+ * \internal
+ * Static-initializer macro for `struct picotm_slist`.
+ * \param   next_   A pointer to the next entry, or NULL.
+ */
+#define __PICOTM_SLIST_INITIALIZER(next_)   \
+    {                                       \
+        .next = (next_)                     \
+    }
+
+/**
+ * \ingroup group_lib
+ * Static-initializer macro for singly-linked list items.
+ */
+#define PICOTM_SLIST_ITEM_INITIALIZER   \
+    __PIOTM_SLIST_INITIALIZER(NULL)
+
+/**
+ * \ingroup group_lib
+ * Static-initializer macro for singly-linked list heads.
+ * \param   head_   The singly-linked list's head entry.
+ */
+#define PICOTM_SLIST_HEAD_INITIALIZER(head_)    \
+    __PIOTM_SLIST_INITIALIZER(head_)
+
+/**
+ * \ingroup group_lib
+ * Initialize an entry of a singly-linked list.
+ * \param   item    The singly-linked list's entry.
+ * \returns The list entry.
+ */
+static inline struct picotm_slist*
+picotm_slist_init_item(struct picotm_slist* item)
+{
+    item->next = NULL;
+    return item;
+}
+
+/**
+ * \ingroup group_lib
+ * Uninitialize an entry of a singly-linked list.
+ * \param   item    The singly-linked list's entry.
+ */
+static inline void
+picotm_slist_uninit_item(struct picotm_slist* item)
+{
+    /* no-op for now */
+}
+
+/**
+ * \ingroup group_lib
+ * Initialize the head entry of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \returns The list head.
+ */
+static inline struct picotm_slist*
+picotm_slist_init_head(struct picotm_slist* head)
+{
+    head->next = head;
+    return head;
+}
+
+/**
+ * \ingroup group_lib
+ * Uninitialize the head entry of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ */
+static inline void
+picotm_slist_uninit_head(struct picotm_slist* head)
+{
+    /* no-op for now */
+}
+
+/**
+ * \ingroup group_lib
+ * Returns true if a singly-linked list item is enqueued.
+ * \param   item    The singly-linked list entry.
+ * \returns True if the entry is enqueued, or false otherwise.
+ */
+static inline _Bool
+picotm_slist_is_enqueued(const struct picotm_slist* item)
+{
+    return !!item->next;
+}
+
+/**
+ * \ingroup group_lib
+ * Returns the next entry in a singly-linked list.
+ * \param   item    The singly-linked list's current entry.
+ * \returns The next entry in the singly-linked list, or the list head
+ *          at the end of the list.
+ */
+static inline struct picotm_slist*
+picotm_slist_next(const struct picotm_slist* item)
+{
+    return item->next;
+}
+
+/**
+ * \ingroup group_lib
+ * Returns the previous entry in a singly-linked list.
+ * \param   item    The singly-linked list's current entry.
+ * \returns The next entry in the singly-linked list, or the list head
+ *          at the beginning of the list.
+ */
+static inline struct picotm_slist*
+picotm_slist_prev(const struct picotm_slist* item)
+{
+    struct picotm_slist* prev = (struct picotm_slist*)item;
+    while (picotm_slist_next(prev) != item) {
+        prev = picotm_slist_next(prev);
+    }
+    return prev;
+}
+
+/**
+ * \ingroup group_lib
+ * Returns the first entry in a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \returns The first entry in the singly-linked list, or the list head
+ *          if the list is empty.
+ */
+static inline struct picotm_slist*
+picotm_slist_begin(const struct picotm_slist* head)
+{
+    return picotm_slist_next(head);
+}
+
+/**
+ * \ingroup group_lib
+ * Returns the terminating entry in a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \returns The terminating entry in the singly-linked list.
+ */
+static inline const struct picotm_slist*
+picotm_slist_end(const struct picotm_slist* head)
+{
+    return head;
+}
+
+/**
+ * \ingroup group_lib
+ * Returns true if a singly-linked list is empty.
+ * \param   head    The singly-linked list's head entry.
+ * \returns True if the singly-linked list is empty, or false otherwise.
+ */
+static inline _Bool
+picotm_slist_is_empty(const struct picotm_slist* head)
+{
+    return picotm_slist_begin(head) == picotm_slist_end(head);
+}
+
+/**
+ * \ingroup group_lib
+ * Enqueues an item to a singly-linked list before an existing item.
+ * \param   item    The singly-linked list's exiting entry.
+ * \param   newitem The new entry for the singly-linked list.
+ */
+static inline void
+picotm_slist_enqueue_before(struct picotm_slist* item,
+                            struct picotm_slist* newitem)
+{
+    struct picotm_slist* prev = picotm_slist_prev(item);
+
+    newitem->next = item;
+    prev->next = newitem;
+}
+
+/**
+ * \ingroup group_lib
+ * Enqueues an item to a singly-linked list after an existing item.
+ * \param   item    The singly-linked list's exiting entry.
+ * \param   newitem The new entry for the singly-linked list.
+ */
+static inline void
+picotm_slist_enqueue_after(struct picotm_slist* item,
+                           struct picotm_slist* newitem)
+{
+    newitem->next = picotm_slist_next(item);
+    item->next = newitem;
+}
+
+/**
+ * \ingroup group_lib
+ * Enqueues an item at the beginning of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   newitem The new entry for the singly-linked list.
+ */
+static inline void
+picotm_slist_enqueue_front(struct picotm_slist* head,
+                           struct picotm_slist* newitem)
+{
+    picotm_slist_enqueue_after(head, newitem);
+}
+
+/**
+ * \ingroup group_lib
+ * Enqueues an item at the end of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   newitem The new entry for the singly-linked list.
+ */
+static inline void
+picotm_slist_enqueue_back(struct picotm_slist* head,
+                          struct picotm_slist* newitem)
+{
+    picotm_slist_enqueue_before(head, newitem);
+}
+
+/**
+ * \ingroup group_lib
+ * Enqueues an item to a sorted singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   newitem The new entry for the singly-linked list.
+ * \param   cmp     The compare-function for sorting the entries.
+ */
+static inline void
+picotm_slist_enqueue_sorted(struct picotm_slist* head,
+                            struct picotm_slist* newitem,
+                            int (*cmp)(struct picotm_slist*,
+                                       struct picotm_slist*))
+{
+    struct picotm_slist* item = picotm_slist_begin(head);
+    struct picotm_slist* prev = head;
+
+    while (item != picotm_slist_end(head)) {
+        if (cmp(newitem, item) > 0) {
+            break;
+        }
+        prev = item;
+        item = picotm_slist_next(item);
+    }
+
+    picotm_slist_enqueue_after(prev, newitem);
+}
+
+/**
+ * \ingroup group_lib
+ * Dequeues an item of a singly-linked list.
+ * \param   item    The singly-linked list's exiting entry.
+ */
+static inline void
+picotm_slist_dequeue(struct picotm_slist* item)
+{
+    struct picotm_slist* prev = picotm_slist_prev(item);
+    prev->next = picotm_slist_next(item);
+    item->next = NULL;
+}
+
+/**
+ * \ingroup group_lib
+ * Dequeues the front item of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ */
+static inline void
+picotm_slist_dequeue_front(struct picotm_slist* head)
+{
+    struct picotm_slist* next = picotm_slist_next(head);
+    head->next = picotm_slist_next(next);
+    next->next = NULL;
+}
+
+/**
+ * \ingroup group_lib
+ * Returns the front item of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \returns The first entry in the singly-linked list, or the list head
+ *          if the list is empty.
+ */
+static inline struct picotm_slist*
+picotm_slist_front(const struct picotm_slist* head)
+{
+    if (picotm_slist_is_empty(head)) {
+        return NULL;
+    }
+    return picotm_slist_begin(head);
+}
+
+/**
+ * \ingroup group_lib
+ * Returns the final item of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \returns The first entry in the singly-linked list, or the list head
+ *          if the list is empty.
+ */
+static inline struct picotm_slist*
+picotm_slist_back(const struct picotm_slist* head)
+{
+    if (picotm_slist_is_empty(head)) {
+        return NULL;
+    }
+    return picotm_slist_prev(picotm_slist_end(head));
+}
+
+/**
+ * \ingroup group_lib
+ * Finds an item in a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   test    The test function for the find operation.
+ * \returns An entry in the singly-linked list, or the list head
+ *          if the entry could not be found.
+ */
+static inline struct picotm_slist*
+picotm_slist_find_0(const struct picotm_slist* head,
+                    _Bool (*test)(const struct picotm_slist*))
+{
+          struct picotm_slist* beg = picotm_slist_begin(head);
+    const struct picotm_slist* end = picotm_slist_end(head);
+
+    for (; beg != end; beg = picotm_slist_next(beg)) {
+        if (test(beg)) {
+            return beg;
+        }
+    }
+    return beg;
+}
+
+/**
+ * \ingroup group_lib
+ * Finds an item in a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   test    The test function for the find operation.
+ * \param   data    The data parameter for the test function.
+ * \returns An entry in the singly-linked list, or the list head
+ *          if the entry could not be found.
+ */
+static inline struct picotm_slist*
+picotm_slist_find_1(const struct picotm_slist* head,
+                    _Bool (*test)(const struct picotm_slist*, void*),
+                    void* data)
+{
+          struct picotm_slist* beg = picotm_slist_begin(head);
+    const struct picotm_slist* end = picotm_slist_end(head);
+
+    for (; beg != end; beg = picotm_slist_next(beg)) {
+        if (test(beg, data)) {
+            return beg;
+        }
+    }
+    return beg;
+}
+
+/**
+ * \ingroup group_lib
+ * Finds an item in a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   test    The test function for the find operation.
+ * \param   data1   The first data parameter for the test function.
+ * \param   data2   The second data parameter for the test function.
+ * \returns An entry in the singly-linked list, or the list head
+ *          if the entry could not be found.
+ */
+static inline struct picotm_slist*
+picotm_slist_find_2(const struct picotm_slist* head,
+                    _Bool (*test)(const struct picotm_slist*, void*, void*),
+                    void* data1, void* data2)
+{
+          struct picotm_slist* beg = picotm_slist_begin(head);
+    const struct picotm_slist* end = picotm_slist_end(head);
+
+    for (; beg != end; beg = picotm_slist_next(beg)) {
+        if (test(beg, data1, data2)) {
+            return beg;
+        }
+    }
+    return beg;
+}
+
+/**
+ * \ingroup group_lib
+ * Walks over all items in a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   walk    The call-back function for each item.
+ * \returns The singly-linked list's head entry on success, or the
+ *          last-processed entry on errors.
+ */
+static inline struct picotm_slist*
+picotm_slist_walk_0(const struct picotm_slist* head,
+                    size_t (*walk)(struct picotm_slist*))
+{
+          struct picotm_slist* beg = picotm_slist_begin(head);
+    const struct picotm_slist* end = picotm_slist_end(head);
+
+    while (beg != end) {
+        size_t incr = walk(beg);
+        if (!incr) {
+            break;
+        }
+        for (; incr && (beg != end); --incr) {
+            beg = picotm_slist_next(beg);
+        }
+    }
+    return beg;
+}
+
+/**
+ * \ingroup group_lib
+ * Walks over all items in a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   walk    The call-back function for each item.
+ * \param   data    The data parameter for the walk function.
+ * \returns The singly-linked list's head entry on success, or the
+ *          last-processed entry on errors.
+ */
+static inline struct picotm_slist*
+picotm_slist_walk_1(const struct picotm_slist* head,
+                    size_t (*walk)(struct picotm_slist*, void* data),
+                    void* data)
+{
+          struct picotm_slist* beg = picotm_slist_begin(head);
+    const struct picotm_slist* end = picotm_slist_end(head);
+
+    while (beg != end) {
+        size_t incr = walk(beg, data);
+        if (!incr) {
+            break;
+        }
+        for (; incr && (beg != end); --incr) {
+            beg = picotm_slist_next(beg);
+        }
+    }
+    return beg;
+}
+
+/**
+ * \ingroup group_lib
+ * Walks over all items in a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   walk    The call-back function for each item.
+ * \param   data1   The first data parameter for the walk function.
+ * \param   data2   The second data parameter for the walk function.
+ * \returns The singly-linked list's head entry on success, or the
+ *          last-processed entry on errors.
+ */
+static inline struct picotm_slist*
+picotm_slist_walk_2(const struct picotm_slist* head,
+                    size_t (*walk)(struct picotm_slist*, void* data1,
+                                   void* data2),
+                    void* data1, void* data2)
+{
+          struct picotm_slist* beg = picotm_slist_begin(head);
+    const struct picotm_slist* end = picotm_slist_end(head);
+
+    while (beg != end) {
+        size_t incr = walk(beg, data1, data2);
+        if (!incr) {
+            break;
+        }
+        for (; incr && (beg != end); --incr) {
+            beg = picotm_slist_next(beg);
+        }
+    }
+    return beg;
+}
+
+/**
+ * \ingroup group_lib
+ * Cleans up all items of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   cleanup The clean-up function for each item.
+ */
+static inline void
+picotm_slist_cleanup_0(struct picotm_slist* head,
+                       void (*cleanup)(struct picotm_slist*))
+{
+    while (!picotm_slist_is_empty(head)) {
+        struct picotm_slist* item = picotm_slist_front(head);
+        picotm_slist_dequeue_front(head);
+        cleanup(item);
+    }
+}
+
+/**
+ * \ingroup group_lib
+ * Cleans up all items of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   cleanup The clean-up function for each item.
+ * \param   data1   The first data parameter for the walk function.
+ */
+static inline void
+picotm_slist_cleanup_1(struct picotm_slist* head,
+                       void (*cleanup)(struct picotm_slist*, void*),
+                       void* data1)
+{
+    while (!picotm_slist_is_empty(head)) {
+        struct picotm_slist* item = picotm_slist_front(head);
+        picotm_slist_dequeue_front(head);
+        cleanup(item, data1);
+    }
+}
+
+/**
+ * \ingroup group_lib
+ * Cleans up all items of a singly-linked list.
+ * \param   head    The singly-linked list's head entry.
+ * \param   cleanup The clean-up function for each item.
+ * \param   data1   The first data parameter for the walk function.
+ * \param   data2   The second data parameter for the walk function.
+ */
+static inline void
+picotm_slist_cleanup_2(struct picotm_slist* head,
+                       void (*cleanup)(struct picotm_slist*, void*, void*),
+                       void* data1, void* data2)
+{
+    while (!picotm_slist_is_empty(head)) {
+        struct picotm_slist* item = picotm_slist_front(head);
+        picotm_slist_dequeue_front(head);
+        cleanup(item, data1, data2);
+    }
+}
+
+PICOTM_END_DECLS

--- a/modules/libc/src/fildes/fd_tx.c
+++ b/modules/libc/src/fildes/fd_tx.c
@@ -98,7 +98,7 @@ fd_tx_init(struct fd_tx* self)
 
     picotm_ref_init(&self->ref, 0);
 
-    memset(&self->active_list, 0, sizeof(self->active_list));
+    picotm_slist_init_item(&self->active_list);
 
     self->fd = NULL;
     self->ofd_tx = NULL;
@@ -118,6 +118,8 @@ fd_tx_uninit(struct fd_tx* self)
 
     uninit_rwstates(picotm_arraybeg(self->rwstate),
                     picotm_arrayend(self->rwstate));
+
+    picotm_slist_uninit_item(&self->active_list);
 }
 
 void

--- a/modules/libc/src/fildes/fd_tx.h
+++ b/modules/libc/src/fildes/fd_tx.h
@@ -25,13 +25,14 @@
 
 #pragma once
 
+#include "picotm/picotm-lib-ptr.h"
 #include "picotm/picotm-lib-ref.h"
 #include "picotm/picotm-lib-rwstate.h"
+#include "picotm/picotm-lib-slist.h"
 #include "picotm/picotm-libc.h"
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include "fd.h"
@@ -60,7 +61,7 @@ struct fd_tx {
 
     struct picotm_ref16 ref;
 
-    SLIST_ENTRY(fd_tx) active_list;
+    struct picotm_slist active_list;
 
     struct fd* fd;
 
@@ -73,6 +74,12 @@ struct fd_tx {
     struct fcntlop* fcntltab;
     size_t          fcntltablen;
 };
+
+static inline struct fd_tx*
+fd_tx_of_slist(struct picotm_slist* item)
+{
+    return picotm_containerof(item, struct fd_tx, active_list);
+}
 
 /**
  * Init transaction-local file-descriptor state

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -3201,6 +3201,18 @@ fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
     }
 }
 
+static void
+finish_fd_tx(struct fd_tx* fd_tx)
+{
+    fd_tx_unref(fd_tx);
+}
+
+static void
+finish_fd_tx_cb(struct picotm_slist* item)
+{
+    finish_fd_tx(fd_tx_of_slist(item));
+}
+
 void
 fildes_tx_finish(struct fildes_tx* self, struct picotm_error* error)
 {
@@ -3225,12 +3237,5 @@ fildes_tx_finish(struct fildes_tx* self, struct picotm_error* error)
     }
 
     /* Unref file descriptors */
-
-    while (!picotm_slist_is_empty(&self->fd_tx_active_list)) {
-        struct fd_tx* fd_tx =
-            fd_tx_of_slist(picotm_slist_front(&self->fd_tx_active_list));
-        picotm_slist_dequeue_front(&self->fd_tx_active_list);
-
-        fd_tx_unref(fd_tx);
-    }
+    picotm_slist_cleanup_0(&self->fd_tx_active_list, finish_fd_tx_cb);
 }

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -3323,6 +3323,18 @@ fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
 }
 
 static void
+finish_file_tx(struct file_tx* file_tx)
+{
+    file_tx_unref(file_tx);
+}
+
+static void
+finish_file_tx_cb(struct picotm_slist* item)
+{
+    finish_file_tx(file_tx_of_slist(item));
+}
+
+static void
 finish_ofd_tx(struct ofd_tx* ofd_tx)
 {
     ofd_tx_unref(ofd_tx);
@@ -3350,13 +3362,7 @@ void
 fildes_tx_finish(struct fildes_tx* self, struct picotm_error* error)
 {
     /* Unref files */
-    while (!picotm_slist_is_empty(&self->file_tx_active_list)) {
-        struct file_tx* file_tx =
-            file_tx_of_slist(picotm_slist_front(&self->file_tx_active_list));
-        picotm_slist_dequeue_front(&self->file_tx_active_list);
-
-        file_tx_unref(file_tx);
-    }
+    picotm_slist_cleanup_0(&self->file_tx_active_list, finish_file_tx_cb);
 
     /* Unref open file descriptions */
     picotm_slist_cleanup_0(&self->ofd_tx_active_list, finish_ofd_tx_cb);

--- a/modules/libc/src/fildes/fildes_tx.h
+++ b/modules/libc/src/fildes/fildes_tx.h
@@ -27,7 +27,6 @@
 
 #include "picotm/picotm-error.h"
 #include "picotm/picotm-lib-slist.h"
-#include <sys/queue.h>
 #include <sys/time.h>
 #include "chrdev_tx.h"
 #include "dir_tx.h"
@@ -50,8 +49,6 @@
 struct fildes_log;
 struct pipeop;
 struct openop;
-
-SLIST_HEAD(file_tx_slist, file_tx);
 
 struct fildes_tx {
 
@@ -81,7 +78,7 @@ struct fildes_tx {
     size_t            socket_tx_max_index;
 
     /** Active instances of `struct file_tx` */
-    struct file_tx_slist  file_tx_active_list;
+    struct picotm_slist  file_tx_active_list;
 
     struct ofd_tx ofd_tx[MAXNUMFD];
     size_t        ofd_tx_max_index;

--- a/modules/libc/src/fildes/fildes_tx.h
+++ b/modules/libc/src/fildes/fildes_tx.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "picotm/picotm-error.h"
+#include "picotm/picotm-lib-slist.h"
 #include <sys/queue.h>
 #include <sys/time.h>
 #include "chrdev_tx.h"
@@ -50,7 +51,6 @@ struct fildes_log;
 struct pipeop;
 struct openop;
 
-SLIST_HEAD(fd_tx_slist, fd_tx);
 SLIST_HEAD(file_tx_slist, file_tx);
 SLIST_HEAD(ofd_tx_slist, ofd_tx);
 
@@ -64,7 +64,7 @@ struct fildes_tx {
     size_t       fd_tx_max_fildes;
 
     /** Active instances of |struct fd_tx| */
-    struct fd_tx_slist  fd_tx_active_list;
+    struct picotm_slist fd_tx_active_list;
 
     struct chrdev_tx chrdev_tx[MAXNUMFD];
     size_t           chrdev_tx_max_index;

--- a/modules/libc/src/fildes/fildes_tx.h
+++ b/modules/libc/src/fildes/fildes_tx.h
@@ -52,7 +52,6 @@ struct pipeop;
 struct openop;
 
 SLIST_HEAD(file_tx_slist, file_tx);
-SLIST_HEAD(ofd_tx_slist, ofd_tx);
 
 struct fildes_tx {
 
@@ -88,7 +87,7 @@ struct fildes_tx {
     size_t        ofd_tx_max_index;
 
     /** Active instances of |struct ofd_tx| */
-    struct ofd_tx_slist ofd_tx_active_list;
+    struct picotm_slist ofd_tx_active_list;
 
     struct openop* openoptab;
     size_t         openoptablen;

--- a/modules/libc/src/fildes/file_tx.c
+++ b/modules/libc/src/fildes/file_tx.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,6 @@
 
 #include "file_tx.h"
 #include <assert.h>
-#include <string.h>
 #include "file_tx_ops.h"
 
 void
@@ -34,14 +33,16 @@ file_tx_init(struct file_tx* self,  const struct file_tx_ops* ops)
     assert(self);
     assert(ops);
 
-    memset(&self->active_list, 0, sizeof(self->active_list));
+    picotm_slist_init_item(&self->active_list);
 
     self->ops = ops;
 }
 
 void
 file_tx_uninit(struct file_tx* self)
-{ }
+{
+    picotm_slist_uninit_item(&self->active_list);
+}
 
 enum picotm_libc_file_type
 file_tx_file_type(const struct file_tx* self)

--- a/modules/libc/src/fildes/file_tx.h
+++ b/modules/libc/src/fildes/file_tx.h
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,8 @@
 
 #pragma once
 
-#include <sys/queue.h>
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-slist.h"
 
 /**
  * \cond impl || libc_impl || libc_impl_fd
@@ -42,10 +43,16 @@ struct picotm_error;
  */
 struct file_tx {
 
-    SLIST_ENTRY(file_tx) active_list;
+    struct picotm_slist active_list;
 
     const struct file_tx_ops* ops;
 };
+
+static inline struct file_tx*
+file_tx_of_slist(struct picotm_slist* item)
+{
+    return picotm_containerof(item, struct file_tx, active_list);
+}
 
 /**
  * \brief Init transaction-local file state.

--- a/modules/libc/src/fildes/ofd_tx.c
+++ b/modules/libc/src/fildes/ofd_tx.c
@@ -95,6 +95,8 @@ ofd_tx_uninit(struct ofd_tx* self)
 
     uninit_rwstates(picotm_arraybeg(self->rwstate),
                     picotm_arrayend(self->rwstate));
+
+    picotm_slist_uninit_item(&self->active_list);
 }
 
 bool

--- a/modules/libc/src/fildes/ofd_tx.c
+++ b/modules/libc/src/fildes/ofd_tx.c
@@ -28,7 +28,6 @@
 #include "picotm/picotm-lib-array.h"
 #include <assert.h>
 #include <errno.h>
-#include <string.h>
 #include <unistd.h>
 #include "file_tx.h"
 #include "seekop.h"
@@ -72,7 +71,7 @@ ofd_tx_init(struct ofd_tx* self)
 
     picotm_ref_init(&self->ref, 0);
 
-    memset(&self->active_list, 0, sizeof(self->active_list));
+    picotm_slist_init_item(&self->active_list);
 
     self->ofd = NULL;
 

--- a/modules/libc/src/fildes/ofd_tx.h
+++ b/modules/libc/src/fildes/ofd_tx.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
+#include "picotm/picotm-lib-ptr.h"
 #include "picotm/picotm-lib-ref.h"
 #include "picotm/picotm-lib-rwstate.h"
-#include <sys/queue.h>
+#include "picotm/picotm-lib-slist.h"
 #include "ofd.h"
 
 /**
@@ -47,7 +48,7 @@ struct ofd_tx {
 
     struct picotm_ref16 ref;
 
-    SLIST_ENTRY(ofd_tx) active_list;
+    struct picotm_slist active_list;
 
     struct ofd* ofd;
 
@@ -62,6 +63,12 @@ struct ofd_tx {
     /** State of the local reader/writer locks. */
     struct picotm_rwstate rwstate[NUMBER_OF_OFD_FIELDS];
 };
+
+static inline struct ofd_tx*
+ofd_tx_of_slist(struct picotm_slist* item)
+{
+    return picotm_containerof(item, struct ofd_tx, active_list);
+}
 
 /**
  * Init transaction-local open-file-description state.

--- a/modules/tm/src/page.c
+++ b/modules/tm/src/page.c
@@ -36,7 +36,7 @@ tm_page_init(struct tm_page* page, size_t block_index)
     page->flags = block_index << TM_BLOCK_SIZE_BITS;
     picotm_rwstate_init(&page->rwstate);
     page->buf_bits = 0;
-    memset(&page->list, 0, sizeof(page->list));
+    picotm_slist_init_item(&page->list);
 }
 
 void

--- a/modules/tm/src/page.h
+++ b/modules/tm/src/page.h
@@ -25,10 +25,11 @@
 
 #pragma once
 
+#include "picotm/picotm-lib-ptr.h"
 #include "picotm/picotm-lib-rwstate.h"
+#include "picotm/picotm-lib-slist.h"
 #include <stdbool.h>
 #include <stdint.h>
-#include <sys/queue.h>
 #include "block.h"
 
 struct tm_vmem;
@@ -56,8 +57,14 @@ struct tm_page {
     uint8_t buf_bits;
 
     /** Entry into allocator lists */
-    SLIST_ENTRY(tm_page) list;
+    struct picotm_slist list;
 };
+
+static inline struct tm_page*
+tm_page_of_slist(struct picotm_slist* item)
+{
+    return picotm_containerof(item, struct tm_page, list);
+}
 
 void
 tm_page_init(struct tm_page* page, size_t block_index);

--- a/modules/tm/src/page.h
+++ b/modules/tm/src/page.h
@@ -66,6 +66,12 @@ tm_page_of_slist(struct picotm_slist* item)
     return picotm_containerof(item, struct tm_page, list);
 }
 
+static inline const struct tm_page*
+tm_page_of_const_slist(const struct picotm_slist* item)
+{
+    return picotm_containerof(item, const struct tm_page, list);
+}
+
 void
 tm_page_init(struct tm_page* page, size_t block_index);
 

--- a/modules/tm/src/vmem_tx.c
+++ b/modules/tm/src/vmem_tx.c
@@ -587,25 +587,31 @@ tm_vmem_tx_validate(struct tm_vmem_tx* vmem_tx, bool eotx,
      * already know that they are in a consistent state. */
 }
 
+static size_t
+apply_page(struct tm_page* page, struct tm_vmem* vmem, struct picotm_error* error)
+{
+    if (tm_page_has_wrlocked_frame(page) &&
+        !(page->flags & TM_PAGE_FLAG_WRITE_THROUGH) &&
+        !(page->flags & TM_PAGE_FLAG_DISCARDED)) {
+        tm_page_st(page, copy_all_bits(), vmem, error);
+        if (picotm_error_is_set(error)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static size_t
+apply_page_cb(struct picotm_slist* item, void* data1, void* data2)
+{
+    return apply_page(tm_page_of_slist(item), data1, data2);
+}
+
 void
 tm_vmem_tx_apply(struct tm_vmem_tx* vmem_tx, struct picotm_error* error)
 {
-    const struct picotm_slist* end =
-        picotm_slist_end(&vmem_tx->active_pages);
-          struct picotm_slist* beg =
-        picotm_slist_begin(&vmem_tx->active_pages);
-
-    for (; beg != end; beg = picotm_slist_next(beg)) {
-        struct tm_page* page = tm_page_of_slist(beg);
-        if (tm_page_has_wrlocked_frame(page) &&
-                !(page->flags & TM_PAGE_FLAG_WRITE_THROUGH) &&
-                !(page->flags & TM_PAGE_FLAG_DISCARDED)) {
-            tm_page_st(page, copy_all_bits(), vmem_tx->vmem, error);
-            if (picotm_error_is_set(error)) {
-                return;
-            }
-        }
-    }
+    picotm_slist_walk_2(&vmem_tx->active_pages, apply_page_cb,
+                        vmem_tx->vmem, error);
 }
 
 void

--- a/modules/tm/src/vmem_tx.h
+++ b/modules/tm/src/vmem_tx.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "picotm/picotm-lib-slist.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/queue.h>
 
 /**
  * \cond impl || tm_impl
@@ -42,8 +42,6 @@ struct tm_page;
 struct tm_vmem;
 struct tm_vmem_tx;
 
-SLIST_HEAD(tm_page_list, tm_page);
-
 /**
  * |struct tm_vmem_tx| represents a memory transaction.
  */
@@ -55,8 +53,8 @@ struct tm_vmem_tx {
     unsigned long module;
 
     /* page-allocator fields */
-    struct tm_page_list active_pages;
-    struct tm_page_list alloced_pages;
+    struct picotm_slist active_pages;
+    struct picotm_slist alloced_pages;
 };
 
 /**

--- a/modules/txlib/src/txlib_tx.c
+++ b/modules/txlib/src/txlib_tx.c
@@ -31,7 +31,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
-#include <string.h>
 #include "txlib_event.h"
 
 void
@@ -41,11 +40,11 @@ txlib_tx_init(struct txlib_tx* self, unsigned long module)
 
     self->module = module;
 
-    SLIST_INIT(&self->allocated_entries);
-    SLIST_INIT(&self->acquired_list_tx);
-    SLIST_INIT(&self->acquired_multiset_tx);
-    SLIST_INIT(&self->acquired_queue_tx);
-    SLIST_INIT(&self->acquired_stack_tx);
+    picotm_slist_init_head(&self->allocated_entries);
+    picotm_slist_init_head(&self->acquired_list_tx);
+    picotm_slist_init_head(&self->acquired_multiset_tx);
+    picotm_slist_init_head(&self->acquired_queue_tx);
+    picotm_slist_init_head(&self->acquired_stack_tx);
 
     self->event = NULL;
     self->nevents = 0;
@@ -54,10 +53,11 @@ txlib_tx_init(struct txlib_tx* self, unsigned long module)
 static void
 free_allocated_txlib_tx_entries(struct txlib_tx* self)
 {
-    struct txlib_tx_entry* entry = SLIST_FIRST(&self->allocated_entries);
-
-    for (; entry; entry = SLIST_FIRST(&self->allocated_entries)) {
-        SLIST_REMOVE_HEAD(&self->allocated_entries, slist_entry);
+    while (!picotm_slist_is_empty(&self->allocated_entries)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(
+            picotm_slist_front(&self->allocated_entries));
+        picotm_slist_dequeue_front(&self->allocated_entries);
+        picotm_slist_uninit_item(&entry->slist_entry);
         free(entry);
     }
 }
@@ -69,10 +69,16 @@ txlib_tx_uninit(struct txlib_tx* self)
 
     free_allocated_txlib_tx_entries(self);
 
-    assert(SLIST_EMPTY(&self->acquired_list_tx));
-    assert(SLIST_EMPTY(&self->acquired_multiset_tx));
-    assert(SLIST_EMPTY(&self->acquired_queue_tx));
-    assert(SLIST_EMPTY(&self->acquired_stack_tx));
+    assert(picotm_slist_is_empty(&self->acquired_list_tx));
+    assert(picotm_slist_is_empty(&self->acquired_multiset_tx));
+    assert(picotm_slist_is_empty(&self->acquired_queue_tx));
+    assert(picotm_slist_is_empty(&self->acquired_stack_tx));
+
+    picotm_slist_uninit_head(&self->allocated_entries);
+    picotm_slist_uninit_head(&self->acquired_list_tx);
+    picotm_slist_uninit_head(&self->acquired_multiset_tx);
+    picotm_slist_uninit_head(&self->acquired_queue_tx);
+    picotm_slist_uninit_head(&self->acquired_stack_tx);
 
     picotm_tabfree(self->event);
 }
@@ -82,22 +88,34 @@ allocate_txlib_tx_entry(struct txlib_tx* self, struct picotm_error* error)
 {
     struct txlib_tx_entry* entry;
 
-    if (SLIST_EMPTY(&self->allocated_entries)) {
+    if (picotm_slist_is_empty(&self->allocated_entries)) {
 
         entry = malloc(sizeof(*entry));
         if (!entry) {
             picotm_error_set_errno(error, errno);
             return NULL;
         }
-        memset(&entry->slist_entry, 0, sizeof(entry->slist_entry));
+        picotm_slist_init_item(&entry->slist_entry);
 
     } else {
-
-        entry = SLIST_FIRST(&self->allocated_entries);
-        SLIST_REMOVE_HEAD(&self->allocated_entries, slist_entry);
+        entry = txlib_tx_entry_of_slist(
+            picotm_slist_front(&self->allocated_entries));
+        picotm_slist_dequeue_front(&self->allocated_entries);
     }
 
     return entry;
+}
+
+static _Bool
+has_txlist_state(const struct txlib_tx_entry* entry, struct txlist_state* list_state)
+{
+    return entry->data.list_tx.list_state == list_state;
+}
+
+static _Bool
+has_txlist_state_cb(const struct picotm_slist* item, void* list_state)
+{
+    return has_txlist_state(txlib_tx_entry_of_slist_const(item), list_state);
 }
 
 struct txlist_tx*
@@ -107,23 +125,37 @@ txlib_tx_acquire_txlist_of_state(struct txlib_tx* self,
 {
     assert(self);
 
-    struct txlib_tx_entry* entry;
-
-    SLIST_FOREACH(entry, &self->acquired_list_tx, slist_entry) {
-        if (entry->data.list_tx.list_state == list_state) {
-            return &entry->data.list_tx;
-        }
+    struct picotm_slist* item = picotm_slist_find1(&self->acquired_list_tx,
+                                                   has_txlist_state_cb,
+                                                   list_state);
+    if (item != picotm_slist_end(&self->acquired_list_tx)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(item);
+        return &entry->data.list_tx;
     }
 
-    entry = allocate_txlib_tx_entry(self, error);
+    struct txlib_tx_entry* entry = allocate_txlib_tx_entry(self, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
 
     txlist_tx_init(&entry->data.list_tx, list_state, self);
-    SLIST_INSERT_HEAD(&self->acquired_list_tx, entry, slist_entry);
+    picotm_slist_enqueue_front(&self->acquired_list_tx, &entry->slist_entry);
 
     return &entry->data.list_tx;
+}
+
+static _Bool
+has_txmultiset_state(const struct txlib_tx_entry* entry,
+                           struct txmultiset_state* multiset_state)
+{
+    return entry->data.multiset_tx.multiset_state == multiset_state;
+}
+
+static _Bool
+has_txmultiset_state_cb(const struct picotm_slist* item, void* multiset_state)
+{
+    return has_txmultiset_state(txlib_tx_entry_of_slist_const(item),
+                                multiset_state);
 }
 
 struct txmultiset_tx*
@@ -133,23 +165,38 @@ txlib_tx_acquire_txmultiset_of_state(struct txlib_tx* self,
 {
     assert(self);
 
-    struct txlib_tx_entry* entry;
-
-    SLIST_FOREACH(entry, &self->acquired_multiset_tx, slist_entry) {
-        if (entry->data.multiset_tx.multiset_state == multiset_state) {
-            return &entry->data.multiset_tx;
-        }
+    struct picotm_slist* item = picotm_slist_find1(&self->acquired_multiset_tx,
+                                                   has_txmultiset_state_cb,
+                                                   multiset_state);
+    if (item != picotm_slist_end(&self->acquired_multiset_tx)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(item);
+        return &entry->data.multiset_tx;
     }
 
-    entry = allocate_txlib_tx_entry(self, error);
+    struct txlib_tx_entry* entry = allocate_txlib_tx_entry(self, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
 
     txmultiset_tx_init(&entry->data.multiset_tx, multiset_state, self);
-    SLIST_INSERT_HEAD(&self->acquired_multiset_tx, entry, slist_entry);
+    picotm_slist_enqueue_front(&self->acquired_multiset_tx,
+                               &entry->slist_entry);
 
     return &entry->data.multiset_tx;
+}
+
+static _Bool
+has_txqueue_state(const struct txlib_tx_entry* entry,
+                        struct txqueue_state* queue_state)
+{
+    return entry->data.queue_tx.queue_state == queue_state;
+}
+
+static _Bool
+has_txqueue_state_cb(const struct picotm_slist* item, void* queue_state)
+{
+    return has_txqueue_state(txlib_tx_entry_of_slist_const(item),
+                             queue_state);
 }
 
 struct txqueue_tx*
@@ -159,23 +206,37 @@ txlib_tx_acquire_txqueue_of_state(struct txlib_tx* self,
 {
     assert(self);
 
-    struct txlib_tx_entry* entry;
-
-    SLIST_FOREACH(entry, &self->acquired_queue_tx, slist_entry) {
-        if (entry->data.queue_tx.queue_state == queue_state) {
-            return &entry->data.queue_tx;
-        }
+    struct picotm_slist* item = picotm_slist_find1(&self->acquired_queue_tx,
+                                                   has_txqueue_state_cb,
+                                                   queue_state);
+    if (item != picotm_slist_end(&self->acquired_queue_tx)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(item);
+        return &entry->data.queue_tx;
     }
 
-    entry = allocate_txlib_tx_entry(self, error);
+    struct txlib_tx_entry* entry = allocate_txlib_tx_entry(self, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
 
     txqueue_tx_init(&entry->data.queue_tx, queue_state, self);
-    SLIST_INSERT_HEAD(&self->acquired_queue_tx, entry, slist_entry);
+    picotm_slist_enqueue_front(&self->acquired_queue_tx, &entry->slist_entry);
 
     return &entry->data.queue_tx;
+}
+
+static _Bool
+has_txstack_state(const struct txlib_tx_entry* entry,
+                        struct txstack_state* stack_state)
+{
+    return entry->data.stack_tx.stack_state == stack_state;
+}
+
+static _Bool
+has_txstack_state_cb(const struct picotm_slist* item, void* stack_state)
+{
+    return has_txstack_state(txlib_tx_entry_of_slist_const(item),
+                             stack_state);
 }
 
 struct txstack_tx*
@@ -185,21 +246,21 @@ txlib_tx_acquire_txstack_of_state(struct txlib_tx* self,
 {
     assert(self);
 
-    struct txlib_tx_entry* entry;
-
-    SLIST_FOREACH(entry, &self->acquired_stack_tx, slist_entry) {
-        if (entry->data.stack_tx.stack_state == stack_state) {
-            return &entry->data.stack_tx;
-        }
+    struct picotm_slist* item = picotm_slist_find1(&self->acquired_stack_tx,
+                                                   has_txstack_state_cb,
+                                                   stack_state);
+    if (item != picotm_slist_end(&self->acquired_stack_tx)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(item);
+        return &entry->data.stack_tx;
     }
 
-    entry = allocate_txlib_tx_entry(self, error);
+    struct txlib_tx_entry* entry = allocate_txlib_tx_entry(self, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
 
     txstack_tx_init(&entry->data.stack_tx, stack_state, self);
-    SLIST_INSERT_HEAD(&self->acquired_stack_tx, entry, slist_entry);
+    picotm_slist_enqueue_front(&self->acquired_stack_tx, &entry->slist_entry);
 
     return &entry->data.stack_tx;
 }
@@ -284,19 +345,47 @@ txlib_tx_append_events1(struct txlib_tx* self, size_t nevents,
  * Module interface
  */
 
+static size_t
+lock_txqueue_tx_entry(struct txlib_tx_entry* entry,
+                      struct picotm_error* error)
+{
+    txqueue_tx_lock(&entry->data.queue_tx, error);
+    if (picotm_error_is_set(error)) {
+        return 0;
+    }
+    return 1;
+}
+
+static size_t
+lock_txqueue_tx_entry_cb(struct picotm_slist* item, void* data)
+{
+    return lock_txqueue_tx_entry(txlib_tx_entry_of_slist(item), data);
+}
+
 static void
 lock_txqueue_tx_entries(struct txlib_tx* self, struct picotm_error* error)
 {
     assert(self);
 
-    struct txlib_tx_entry* entry;
+    picotm_slist_walk_1(&self->acquired_queue_tx, lock_txqueue_tx_entry_cb,
+                        error);
+}
 
-    SLIST_FOREACH(entry, &self->acquired_queue_tx, slist_entry) {
-        txqueue_tx_lock(&entry->data.queue_tx, error);
-        if (picotm_error_is_set(error)) {
-            return;
-        }
+static size_t
+lock_txstack_tx_entry(struct txlib_tx_entry* entry,
+                      struct picotm_error* error)
+{
+    txstack_tx_lock(&entry->data.stack_tx, error);
+    if (picotm_error_is_set(error)) {
+        return 0;
     }
+    return 1;
+}
+
+static size_t
+lock_txstack_tx_entry_cb(struct picotm_slist* item, void* data)
+{
+    return lock_txstack_tx_entry(txlib_tx_entry_of_slist(item), data);
 }
 
 static void
@@ -304,19 +393,17 @@ lock_txstack_tx_entries(struct txlib_tx* self, struct picotm_error* error)
 {
     assert(self);
 
-    struct txlib_tx_entry* entry;
-
-    SLIST_FOREACH(entry, &self->acquired_stack_tx, slist_entry) {
-        txstack_tx_lock(&entry->data.stack_tx, error);
-        if (picotm_error_is_set(error)) {
-            return;
-        }
-    }
+    picotm_slist_walk_1(&self->acquired_stack_tx, lock_txstack_tx_entry_cb,
+                        error);
 }
 
 void
 txlib_tx_lock(struct txlib_tx* self, struct picotm_error* error)
 {
+    /* Currently, no locking is required for lists and multisets. Both
+     * data structures acquire their locks during the transaction's
+     * execution phase. */
+
     lock_txqueue_tx_entries(self, error);
     if (picotm_error_is_set(error)) {
         return;
@@ -357,56 +444,64 @@ txlib_tx_undo_event(struct txlib_tx* self, unsigned short op,
 static void
 finish_txlist_tx_entries(struct txlib_tx* self)
 {
-    struct txlib_tx_entry* entry = SLIST_FIRST(&self->acquired_list_tx);
+    while (!picotm_slist_is_empty(&self->acquired_list_tx)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(
+            picotm_slist_front(&self->acquired_list_tx));
+        picotm_slist_dequeue_front(&self->acquired_list_tx);
 
-    for (; entry; entry = SLIST_FIRST(&self->acquired_list_tx)) {
         txlist_tx_finish(&entry->data.list_tx);
         txlist_tx_uninit(&entry->data.list_tx);
 
-        SLIST_REMOVE_HEAD(&self->acquired_list_tx, slist_entry);
-        SLIST_INSERT_HEAD(&self->allocated_entries, entry, slist_entry);
+        picotm_slist_enqueue_front(&self->allocated_entries,
+                                   &entry->slist_entry);
     }
 }
 
 static void
 finish_txmultiset_tx_entries(struct txlib_tx* self)
 {
-    struct txlib_tx_entry* entry = SLIST_FIRST(&self->acquired_multiset_tx);
+    while (!picotm_slist_is_empty(&self->acquired_multiset_tx)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(
+            picotm_slist_front(&self->acquired_multiset_tx));
+        picotm_slist_dequeue_front(&self->acquired_multiset_tx);
 
-    for (; entry; entry = SLIST_FIRST(&self->acquired_multiset_tx)) {
         txmultiset_tx_finish(&entry->data.multiset_tx);
         txmultiset_tx_uninit(&entry->data.multiset_tx);
 
-        SLIST_REMOVE_HEAD(&self->acquired_multiset_tx, slist_entry);
-        SLIST_INSERT_HEAD(&self->allocated_entries, entry, slist_entry);
+        picotm_slist_enqueue_front(&self->allocated_entries,
+                                   &entry->slist_entry);
     }
 }
 
 static void
 finish_txqueue_tx_entries(struct txlib_tx* self)
 {
-    struct txlib_tx_entry* entry = SLIST_FIRST(&self->acquired_queue_tx);
+    while (!picotm_slist_is_empty(&self->acquired_queue_tx)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(
+            picotm_slist_front(&self->acquired_queue_tx));
+        picotm_slist_dequeue_front(&self->acquired_queue_tx);
 
-    for (; entry; entry = SLIST_FIRST(&self->acquired_queue_tx)) {
         txqueue_tx_finish(&entry->data.queue_tx);
         txqueue_tx_uninit(&entry->data.queue_tx);
 
-        SLIST_REMOVE_HEAD(&self->acquired_queue_tx, slist_entry);
-        SLIST_INSERT_HEAD(&self->allocated_entries, entry, slist_entry);
+        picotm_slist_enqueue_front(&self->allocated_entries,
+                                   &entry->slist_entry);
     }
 }
 
 static void
 finish_txstack_tx_entries(struct txlib_tx* self)
 {
-    struct txlib_tx_entry* entry = SLIST_FIRST(&self->acquired_stack_tx);
+    while (!picotm_slist_is_empty(&self->acquired_stack_tx)) {
+        struct txlib_tx_entry* entry = txlib_tx_entry_of_slist(
+            picotm_slist_front(&self->acquired_stack_tx));
+        picotm_slist_dequeue_front(&self->acquired_stack_tx);
 
-    for (; entry; entry = SLIST_FIRST(&self->acquired_stack_tx)) {
         txstack_tx_finish(&entry->data.stack_tx);
         txstack_tx_uninit(&entry->data.stack_tx);
 
-        SLIST_REMOVE_HEAD(&self->acquired_stack_tx, slist_entry);
-        SLIST_INSERT_HEAD(&self->allocated_entries, entry, slist_entry);
+        picotm_slist_enqueue_front(&self->allocated_entries,
+                                   &entry->slist_entry);
     }
 }
 

--- a/modules/txlib/src/txlib_tx.h
+++ b/modules/txlib/src/txlib_tx.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
+#include "picotm/picotm-lib-ptr.h"
+#include "picotm/picotm-lib-slist.h"
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/queue.h>
 #include "txlist_tx.h"
 #include "txmultiset_tx.h"
 #include "txqueue_tx.h"
@@ -45,7 +46,7 @@ struct txlib_event;
 
 struct txlib_tx_entry {
 
-    SLIST_ENTRY(txlib_tx_entry) slist_entry;
+    struct picotm_slist slist_entry;
 
     union {
         struct txlist_tx list_tx;
@@ -55,14 +56,26 @@ struct txlib_tx_entry {
     } data;
 };
 
+static inline struct txlib_tx_entry*
+txlib_tx_entry_of_slist(struct picotm_slist* item)
+{
+    return picotm_containerof(item, struct txlib_tx_entry, slist_entry);
+}
+
+static inline const struct txlib_tx_entry*
+txlib_tx_entry_of_slist_const(const struct picotm_slist* item)
+{
+    return picotm_containerof(item, const struct txlib_tx_entry, slist_entry);
+}
+
 struct txlib_tx {
     unsigned long module;
 
-    SLIST_HEAD(, txlib_tx_entry) allocated_entries;
-    SLIST_HEAD(, txlib_tx_entry) acquired_list_tx;
-    SLIST_HEAD(, txlib_tx_entry) acquired_multiset_tx;
-    SLIST_HEAD(, txlib_tx_entry) acquired_queue_tx;
-    SLIST_HEAD(, txlib_tx_entry) acquired_stack_tx;
+    struct picotm_slist allocated_entries;
+    struct picotm_slist acquired_list_tx;
+    struct picotm_slist acquired_multiset_tx;
+    struct picotm_slist acquired_queue_tx;
+    struct picotm_slist acquired_stack_tx;
 
     struct txlib_event* event;
     size_t              nevents;


### PR DESCRIPTION
We currently use the list from <sys/queue.h> This header is not standardized and not portable to non-Unix systems, esp. Windows. This patch set adds |struct picotm_slist|, a singly-linked list.