### PR TITLE
Clean-up module ops

### DIFF
--- a/include/picotm/picotm-module.h
+++ b/include/picotm/picotm-module.h
@@ -118,26 +118,6 @@ typedef void (*picotm_module_undo_event_function)(
     struct picotm_error* error);
 
 /**
- * Invoked by picotm to update a module's concurrency control during a commit.
- * \param       data            The pointer to module-specific data.
- * \param       is_irrevocable  True if the transaction is irrevocable, false otherwise.
- * \param[out]  error           Returns an error from the module.
- */
-typedef void (*picotm_module_update_cc_function)(void* data,
-                                                 int is_irrevocable,
-                                                 struct picotm_error* error);
-
-/**
- * Invoked by picotm to clear a module's concurrency control during an abort.
- * \param       data            The pointer to module-specific data.
- * \param       is_irrevocable  True if the transaction is irrevocable, false otherwise.
- * \param[out]  error           Returns an error from the module.
- */
-typedef void (*picotm_module_clear_cc_function)(void* data,
-                                                int is_irrevocable,
-                                                struct picotm_error* error);
-
-/**
  * Invoked by picotm to clean up a module's resources at the end of a
  * transaction.
  * \param       data    The pointer to module-specific data.
@@ -163,8 +143,6 @@ struct picotm_module_ops {
     picotm_module_undo_function undo;
     picotm_module_apply_event_function apply_event;
     picotm_module_undo_event_function undo_event;
-    picotm_module_update_cc_function update_cc;
-    picotm_module_clear_cc_function clear_cc;
     picotm_module_finish_function finish;
     picotm_module_uninit_function uninit;
 };

--- a/include/picotm/picotm-module.h
+++ b/include/picotm/picotm-module.h
@@ -300,14 +300,6 @@ picotm_recover_from_error(const struct picotm_error* error);
 
 PICOTM_NOTHROW
 /**
- * Validates the transaction state.
- * \returns True if the transaction state is valid, false otherwise.
- */
-bool
-picotm_is_valid(void);
-
-PICOTM_NOTHROW
-/**
  * Makes the current transaction irrevocable.
  */
 void

--- a/include/picotm/picotm-module.h
+++ b/include/picotm/picotm-module.h
@@ -63,32 +63,15 @@ typedef void (*picotm_module_begin_function)(void* data,
                                              struct picotm_error* error);
 
 /**
- * Invoked by picotm to lock a module's resources at the beginning
- * of a commit.
- * \param       data    The pointer to module-specific data.
- * \param[out]  error   Returns an error from the module.
- */
-typedef void (*picotm_module_lock_function)(void* data,
-                                            struct picotm_error* error);
-
-/**
- * Invoked by picotm to unlock a module's resources. This is the inverse
- * of picotm_module_lock_function.
- * \param       data    The pointer to module-specific data.
- * \param[out]  error   Returns an error from the module.
- */
-typedef void (*picotm_module_unlock_function)(void* data,
-                                              struct picotm_error* error);
-
-/**
- * Invoked by picotm to validate a module's resources.
+ * Invoked by picotm to prepare a module's resources for commit.
  * \param       data            The pointer to module-specific data.
  * \param       is_irrevocable  True if the transaction is irrevocable, false otherwise.
  * \param[out]  error           Returns an error from the module.
  */
-typedef void (*picotm_module_validate_function)(void* data,
-                                                int is_irrevocable,
-                                                struct picotm_error* error);
+typedef void (*picotm_module_prepare_commit_function)(
+    void* data,
+    int is_irrevocable,
+    struct picotm_error* error);
 
 /**
  * Invoked by picotm during the commit phase to apply changes of a
@@ -175,9 +158,7 @@ typedef void (*picotm_module_uninit_function)(void* data);
  */
 struct picotm_module_ops {
     picotm_module_begin_function begin;
-    picotm_module_lock_function lock;
-    picotm_module_unlock_function unlock;
-    picotm_module_validate_function validate;
+    picotm_module_prepare_commit_function prepare_commit;
     picotm_module_apply_function apply;
     picotm_module_undo_function undo;
     picotm_module_apply_event_function apply_event;

--- a/include/picotm/picotm-module.h
+++ b/include/picotm/picotm-module.h
@@ -337,8 +337,9 @@ PICOTM_END_DECLS
  *
  * # Registering Your Module
  *
- * To register a module, call picotm_register_module(). The call receives a
- * number of module-specific call-back functions and module data, and returns
+ * To register a module, call `picotm_register_module()`. The call receives
+ * an instance of `struct picotm_module_ops`, which stores a number of
+ * module-specific call-back functions, and variable module data. It returns
  * a unique module number. The call-back functions are invoked by picotm to
  * instruct the module during different phases of a transaction. The returned
  * module number is later required when inserting events into the transaction
@@ -348,22 +349,14 @@ PICOTM_END_DECLS
  * module might look like this.
  *
  * ~~~{.c}
+ *  static const struct picotm_module_ops ops = {
+ *      .apply_event = apply, // See below.
+ *      .undo_event = undo  // See below.
+ *  };
+ *
  *  struct picotm_error error = PICOTM_ERROR_INITIALIZER;
  *
- *  unsigned long module_number =
- *      picotm_register_module(NULL,
- *                             NULL,
- *                             NULL,
- *                             NULL,
- *                             NULL,
- *                             apply, // See below.
- *                             undo,  // See below.
- *                             NULL,
- *                             NULL,
- *                             NULL,
- *                             NULL,
- *                             NULL,
- *                             &error);
+ *  unsigned long module_number = picotm_register_module(&ops, NULL, &error);
  *  if (picotm_error_is_set(&error)) {
  *      // abort with an error
  *  }

--- a/modules/libc/src/cwd/cwd_tx.c
+++ b/modules/libc/src/cwd/cwd_tx.c
@@ -340,29 +340,12 @@ cwd_tx_undo_event(struct cwd_tx* self, enum cwd_op op, char* alloced,
 }
 
 void
-cwd_tx_update_cc(struct cwd_tx* self, struct picotm_error* error)
-{
-    assert(self);
-
-    /* release reader/writer locks on current working directory */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->cwd);
-}
-
-void
-cwd_tx_clear_cc(struct cwd_tx* self, struct picotm_error* error)
-{
-    assert(self);
-
-    /* release reader/writer locks on current working directory */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->cwd);
-}
-
-void
 cwd_tx_finish(struct cwd_tx* self)
 {
     assert(self);
+
+    /* release reader/writer locks on current working directory */
+    unlock_rwstates(picotm_arraybeg(self->rwstate),
+                    picotm_arrayend(self->rwstate),
+                    self->cwd);
 }

--- a/modules/libc/src/cwd/cwd_tx.h
+++ b/modules/libc/src/cwd/cwd_tx.h
@@ -116,10 +116,4 @@ cwd_tx_undo_event(struct cwd_tx* self, enum cwd_op op, char* alloced,
                   struct picotm_error* error);
 
 void
-cwd_tx_update_cc(struct cwd_tx* self, struct picotm_error* error);
-
-void
-cwd_tx_clear_cc(struct cwd_tx* self, struct picotm_error* error);
-
-void
 cwd_tx_finish(struct cwd_tx* self);

--- a/modules/libc/src/cwd/module.c
+++ b/modules/libc/src/cwd/module.c
@@ -115,18 +115,6 @@ module_undo_event(struct module* module, uint16_t head, uintptr_t tail,
 }
 
 static void
-module_update_cc(struct module* module, struct picotm_error* error)
-{
-    cwd_tx_update_cc(&module->tx, error);
-}
-
-static void
-module_clear_cc(struct module* module, struct picotm_error* error)
-{
-    cwd_tx_clear_cc(&module->tx, error);
-}
-
-static void
 module_finish(struct module* module)
 {
     cwd_tx_finish(&module->tx);
@@ -161,18 +149,6 @@ undo_event_cb(uint16_t head, uintptr_t tail, void* data,
 }
 
 static void
-update_cc_cb(void* data, int noundo, struct picotm_error* error)
-{
-    module_update_cc(data, error);
-}
-
-static void
-clear_cc_cb(void* data, int noundo, struct picotm_error* error)
-{
-    module_clear_cc(data, error);
-}
-
-static void
 finish_cb(void* data, struct picotm_error* error)
 {
     module_finish(data);
@@ -190,8 +166,6 @@ get_cwd_tx(bool initialize, struct picotm_error* error)
     static const struct picotm_module_ops g_ops = {
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,
-        .update_cc = update_cc_cb,
-        .clear_cc = clear_cc_cb,
         .finish = finish_cb,
         .uninit = uninit_cb
     };

--- a/modules/libc/src/fildes/chrdev_tx.c
+++ b/modules/libc/src/fildes/chrdev_tx.c
@@ -429,25 +429,8 @@ write_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Module interface
  */
 
-/* Update CC
- */
-
 static void
-update_cc(struct file_tx* base, struct picotm_error* error)
-{
-    struct chrdev_tx* self = chrdev_tx_of_file_tx(base);
-
-    /* release reader/writer locks on character-device state */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->chrdev);
-}
-
-/* Clear CC
- */
-
-static void
-clear_cc(struct file_tx* base, struct picotm_error* error)
+finish(struct file_tx* base)
 {
     struct chrdev_tx* self = chrdev_tx_of_file_tx(base);
 
@@ -467,8 +450,7 @@ static const struct file_tx_ops chrdev_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    update_cc,
-    clear_cc,
+    finish,
     /* file ops */
     file_tx_op_accept_exec_enotsock,
     NULL,

--- a/modules/libc/src/fildes/chrdev_tx.c
+++ b/modules/libc/src/fildes/chrdev_tx.c
@@ -429,21 +429,6 @@ write_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Module interface
  */
 
-static void
-lock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-static void
-unlock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-/* Validation
- */
-
-static void
-validate(struct file_tx* base, struct picotm_error* error)
-{ }
-
 /* Update CC
  */
 
@@ -482,9 +467,6 @@ static const struct file_tx_ops chrdev_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    lock,
-    unlock,
-    validate,
     update_cc,
     clear_cc,
     /* file ops */

--- a/modules/libc/src/fildes/dir_tx.c
+++ b/modules/libc/src/fildes/dir_tx.c
@@ -323,21 +323,6 @@ fsync_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Module interface
  */
 
-static void
-lock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-static void
-unlock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-/* Validation
- */
-
-static void
-validate(struct file_tx* base, struct picotm_error* error)
-{ }
-
 /* Update CC
  */
 
@@ -376,9 +361,6 @@ static const struct file_tx_ops dir_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    lock,
-    unlock,
-    validate,
     update_cc,
     clear_cc,
     /* file ops */

--- a/modules/libc/src/fildes/dir_tx.c
+++ b/modules/libc/src/fildes/dir_tx.c
@@ -323,25 +323,8 @@ fsync_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Module interface
  */
 
-/* Update CC
- */
-
 static void
-update_cc(struct file_tx* base, struct picotm_error* error)
-{
-    struct dir_tx* self = dir_tx_of_file_tx(base);
-
-    /* release reader/writer locks on directory state */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->dir);
-}
-
-/* Clear CC
- */
-
-static void
-clear_cc(struct file_tx* base, struct picotm_error* error)
+finish(struct file_tx* base)
 {
     struct dir_tx* self = dir_tx_of_file_tx(base);
 
@@ -361,8 +344,7 @@ static const struct file_tx_ops dir_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    update_cc,
-    clear_cc,
+    finish,
     /* file ops */
     file_tx_op_accept_exec_enotsock,
     NULL,

--- a/modules/libc/src/fildes/fd.c
+++ b/modules/libc/src/fildes/fd.c
@@ -130,12 +130,6 @@ fd_is_open_nl(const struct fd* self)
 	return self->state == FD_STATE_INUSE;
 }
 
-void
-fd_validate(struct fd* self, struct picotm_error* error)
-{
-    assert(self);
-}
-
 /*
  * Referencing
  */

--- a/modules/libc/src/fildes/fd.h
+++ b/modules/libc/src/fildes/fd.h
@@ -122,10 +122,6 @@ void
 fd_unlock_field(struct fd* self, enum fd_field field,
                 struct picotm_rwstate* state);
 
-/** \brief Validates a file descriptor. */
-void
-fd_validate(struct fd* self, struct picotm_error* error);
-
 /** \brief Aquires a reference on the file dscriptor */
 void
 fd_ref(struct fd* self, struct picotm_error* error);

--- a/modules/libc/src/fildes/fd_tx.c
+++ b/modules/libc/src/fildes/fd_tx.c
@@ -222,19 +222,7 @@ fd_tx_prepare_commit(struct fd_tx* self, struct picotm_error* error)
 }
 
 void
-fd_tx_update_cc(struct fd_tx* self, struct picotm_error* error)
-{
-    assert(self);
-    assert(fd_tx_holds_ref(self));
-
-    /* release reader/writer locks on file-descriptor state */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->fd);
-}
-
-void
-fd_tx_clear_cc(struct fd_tx* self, struct picotm_error* error)
+fd_tx_finish(struct fd_tx* self)
 {
     assert(self);
     assert(fd_tx_holds_ref(self));

--- a/modules/libc/src/fildes/fd_tx.c
+++ b/modules/libc/src/fildes/fd_tx.c
@@ -193,10 +193,6 @@ fd_tx_signal_close(struct fd_tx* self)
     fd_close(self->fd);
 }
 
-/*
- * Module interface
- */
-
 void
 fd_tx_validate(struct fd_tx* self, struct picotm_error* error)
 {
@@ -211,6 +207,18 @@ fd_tx_validate(struct fd_tx* self, struct picotm_error* error)
         picotm_error_set_conflicting(error, NULL);
         return;
     }
+}
+
+/*
+ * Module interface
+ */
+
+void
+fd_tx_prepare_commit(struct fd_tx* self, struct picotm_error* error)
+{
+    assert(self);
+
+    fd_tx_validate(self, error);
 }
 
 void

--- a/modules/libc/src/fildes/fd_tx.c
+++ b/modules/libc/src/fildes/fd_tx.c
@@ -198,14 +198,6 @@ fd_tx_signal_close(struct fd_tx* self)
  */
 
 void
-fd_tx_lock(struct fd_tx* self)
-{ }
-
-void
-fd_tx_unlock(struct fd_tx* self)
-{ }
-
-void
 fd_tx_validate(struct fd_tx* self, struct picotm_error* error)
 {
     assert(self);

--- a/modules/libc/src/fildes/fd_tx.h
+++ b/modules/libc/src/fildes/fd_tx.h
@@ -106,10 +106,7 @@ void
 fd_tx_prepare_commit(struct fd_tx* self, struct picotm_error* error);
 
 void
-fd_tx_update_cc(struct fd_tx* self, struct picotm_error* error);
-
-void
-fd_tx_clear_cc(struct fd_tx* self, struct picotm_error* error);
+fd_tx_finish(struct fd_tx* self);
 
 /**
  * Aquire a reference on file-descriptor state

--- a/modules/libc/src/fildes/fd_tx.h
+++ b/modules/libc/src/fildes/fd_tx.h
@@ -99,6 +99,12 @@ fd_tx_uninit(struct fd_tx* self);
 void
 fd_tx_validate(struct fd_tx* self, struct picotm_error* error);
 
+/**
+ * Prepare transaction-local state for commit
+ */
+void
+fd_tx_prepare_commit(struct fd_tx* self, struct picotm_error* error);
+
 void
 fd_tx_update_cc(struct fd_tx* self, struct picotm_error* error);
 

--- a/modules/libc/src/fildes/fd_tx.h
+++ b/modules/libc/src/fildes/fd_tx.h
@@ -131,12 +131,6 @@ fd_tx_unref(struct fd_tx* self);
 bool
 fd_tx_holds_ref(const struct fd_tx* self);
 
-void
-fd_tx_lock(struct fd_tx* self);
-
-void
-fd_tx_unlock(struct fd_tx* self);
-
 /**
  * Set file descriptor to CLOSING
  */

--- a/modules/libc/src/fildes/fdtab_tx.c
+++ b/modules/libc/src/fildes/fdtab_tx.c
@@ -90,15 +90,7 @@ fdtab_tx_ref_fildes(struct fdtab_tx* self, int fildes,
  */
 
 void
-fdtab_tx_update_cc(struct fdtab_tx* self, struct picotm_error* error)
-{
-    assert(self);
-
-    fdtab_unlock(&self->rwstate);
-}
-
-void
-fdtab_tx_clear_cc(struct fdtab_tx* self, struct picotm_error* error)
+fdtab_tx_finish(struct fdtab_tx* self)
 {
     assert(self);
 

--- a/modules/libc/src/fildes/fdtab_tx.h
+++ b/modules/libc/src/fildes/fdtab_tx.h
@@ -55,7 +55,4 @@ fdtab_tx_ref_fildes(struct fdtab_tx* self, int fildes,
  */
 
 void
-fdtab_tx_update_cc(struct fdtab_tx* self, struct picotm_error* error);
-
-void
-fdtab_tx_clear_cc(struct fdtab_tx* self, struct picotm_error* error);
+fdtab_tx_finish(struct fdtab_tx* self);

--- a/modules/libc/src/fildes/fifo_tx.c
+++ b/modules/libc/src/fildes/fifo_tx.c
@@ -428,21 +428,6 @@ write_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Public interfaces
  */
 
-static void
-lock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-static void
-unlock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-/* Validation
- */
-
-static void
-validate(struct file_tx* base, struct picotm_error* error)
-{ }
-
 /* Update CC
  */
 
@@ -481,9 +466,6 @@ static const struct file_tx_ops fifo_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    lock,
-    unlock,
-    validate,
     update_cc,
     clear_cc,
     /* file ops */

--- a/modules/libc/src/fildes/fifo_tx.c
+++ b/modules/libc/src/fildes/fifo_tx.c
@@ -428,25 +428,8 @@ write_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Public interfaces
  */
 
-/* Update CC
- */
-
 static void
-update_cc(struct file_tx* base, struct picotm_error* error)
-{
-    struct fifo_tx* self = fifo_tx_of_file_tx(base);
-
-    /* release reader/writer locks on FIFO state */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->fifo);
-}
-
-/* Clear CC
- */
-
-static void
-clear_cc(struct file_tx* base, struct picotm_error* error)
+finish(struct file_tx* base)
 {
     struct fifo_tx* self = fifo_tx_of_file_tx(base);
 
@@ -466,8 +449,7 @@ static const struct file_tx_ops fifo_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    update_cc,
-    clear_cc,
+    finish,
     /* file ops */
     file_tx_op_accept_exec_enotsock,
     NULL,

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -2998,25 +2998,12 @@ fildes_tx_undo_event(struct fildes_tx* self, enum fildes_op op, int fildes,
 void
 fildes_tx_update_cc(struct fildes_tx* self, int noundo,
                     struct picotm_error* error)
-{
-    /* Update concurrency control on file-descriptor table */
-    fdtab_tx_update_cc(&self->fdtab_tx, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-}
+{ }
 
 void
 fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
                    struct picotm_error* error)
-{
-    /* Clear concurrency control on file-descriptor table */
-
-    fdtab_tx_update_cc(&self->fdtab_tx, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-}
+{ }
 
 static void
 finish_file_tx(struct file_tx* file_tx)
@@ -3068,4 +3055,7 @@ fildes_tx_finish(struct fildes_tx* self, struct picotm_error* error)
 
     /* Unref file descriptors */
     picotm_slist_cleanup_0(&self->fd_tx_active_list, finish_fd_tx_cb);
+
+    /* Clear concurrency control on file-descriptor table */
+    fdtab_tx_finish(&self->fdtab_tx);
 }

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -3027,22 +3027,6 @@ update_ofd_tx_cc_cb(struct picotm_slist* item, void* data)
     return update_ofd_tx_cc(ofd_tx_of_slist(item), data);
 }
 
-static size_t
-update_file_tx_cc(struct file_tx* file_tx, struct picotm_error* error)
-{
-    file_tx_update_cc(file_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-update_file_tx_cc_cb(struct picotm_slist* item, void* data)
-{
-    return update_file_tx_cc(file_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_update_cc(struct fildes_tx* self, int noundo,
                     struct picotm_error* error)
@@ -3055,13 +3039,6 @@ fildes_tx_update_cc(struct fildes_tx* self, int noundo,
 
     /* Update concurrency control on open file descriptions */
     picotm_slist_walk_1(&self->ofd_tx_active_list, update_ofd_tx_cc_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
-    /* Update concurrency control on files */
-    picotm_slist_walk_1(&self->file_tx_active_list, update_file_tx_cc_cb,
-                        error);
     if (picotm_error_is_set(error)) {
         return;
     }
@@ -3105,22 +3082,6 @@ clear_ofd_tx_cc_cb(struct picotm_slist* item, void* data)
     return clear_ofd_tx_cc(ofd_tx_of_slist(item), data);
 }
 
-static size_t
-clear_file_tx_cc(struct file_tx* file_tx, struct picotm_error* error)
-{
-    file_tx_clear_cc(file_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-clear_file_tx_cc_cb(struct picotm_slist* item, void* data)
-{
-    return clear_file_tx_cc(file_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
                    struct picotm_error* error)
@@ -3137,13 +3098,6 @@ fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
         return;
     }
 
-    /* Clear concurrency control on files */
-    picotm_slist_walk_1(&self->file_tx_active_list, clear_file_tx_cc_cb,
-                        error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
     /* Clear concurrency control on file-descriptor table */
 
     fdtab_tx_update_cc(&self->fdtab_tx, error);
@@ -3155,6 +3109,7 @@ fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
 static void
 finish_file_tx(struct file_tx* file_tx)
 {
+    file_tx_finish(file_tx);
     file_tx_unref(file_tx);
 }
 

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -3011,34 +3011,12 @@ update_fd_tx_cc_cb(struct picotm_slist* item, void* data)
     return update_fd_tx_cc(fd_tx_of_slist(item), data);
 }
 
-static size_t
-update_ofd_tx_cc(struct ofd_tx* ofd_tx, struct picotm_error* error)
-{
-    ofd_tx_update_cc(ofd_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-update_ofd_tx_cc_cb(struct picotm_slist* item, void* data)
-{
-    return update_ofd_tx_cc(ofd_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_update_cc(struct fildes_tx* self, int noundo,
                     struct picotm_error* error)
 {
     /* Update concurrency control on file descriptors */
     picotm_slist_walk_1(&self->fd_tx_active_list, update_fd_tx_cc_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
-    /* Update concurrency control on open file descriptions */
-    picotm_slist_walk_1(&self->ofd_tx_active_list, update_ofd_tx_cc_cb, error);
     if (picotm_error_is_set(error)) {
         return;
     }
@@ -3066,34 +3044,12 @@ clear_fd_tx_cc_cb(struct picotm_slist* item, void* data)
     return clear_fd_tx_cc(fd_tx_of_slist(item), data);
 }
 
-static size_t
-clear_ofd_tx_cc(struct ofd_tx* ofd_tx, struct picotm_error* error)
-{
-    ofd_tx_clear_cc(ofd_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-clear_ofd_tx_cc_cb(struct picotm_slist* item, void* data)
-{
-    return clear_ofd_tx_cc(ofd_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
                    struct picotm_error* error)
 {
     /* Clear concurrency control on file descriptors */
     picotm_slist_walk_1(&self->fd_tx_active_list, clear_fd_tx_cc_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
-    /* Clear concurrency control on open file descriptions */
-    picotm_slist_walk_1(&self->ofd_tx_active_list, clear_ofd_tx_cc_cb, error);
     if (picotm_error_is_set(error)) {
         return;
     }
@@ -3122,6 +3078,7 @@ finish_file_tx_cb(struct picotm_slist* item)
 static void
 finish_ofd_tx(struct ofd_tx* ofd_tx)
 {
+    ofd_tx_finish(ofd_tx);
     ofd_tx_unref(ofd_tx);
 }
 

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -2908,33 +2908,11 @@ lock_fd_tx_cb(struct picotm_slist* item)
     return lock_fd_tx(fd_tx_of_slist(item));
 }
 
-static size_t
-lock_ofd_tx(struct ofd_tx* ofd_tx, struct picotm_error* error)
-{
-    ofd_tx_lock(ofd_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-lock_ofd_tx_cb(struct picotm_slist* item, void* data)
-{
-    return lock_ofd_tx(ofd_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_lock(struct fildes_tx* self, struct picotm_error* error)
 {
     /* Lock file descriptors */
     picotm_slist_walk_0(&self->fd_tx_active_list, lock_fd_tx_cb);
-
-    /* Lock open file descriptions */
-    picotm_slist_walk_1(&self->ofd_tx_active_list, lock_ofd_tx_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
 }
 
 static size_t
@@ -2950,27 +2928,10 @@ unlock_fd_tx_cb(struct picotm_slist* item)
     return unlock_fd_tx(fd_tx_of_slist(item));
 }
 
-static size_t
-unlock_ofd_tx(struct ofd_tx* ofd_tx)
-{
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-    ofd_tx_unlock(ofd_tx, &error);
-    return 1;
-}
-
-static size_t
-unlock_ofd_tx_cb(struct picotm_slist* item)
-{
-    return unlock_ofd_tx(ofd_tx_of_slist(item));
-}
-
 void
 fildes_tx_unlock(struct fildes_tx* self)
 {
     struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    /* Unlock open file descriptions */
-    picotm_slist_walk_0(&self->ofd_tx_active_list, unlock_ofd_tx_cb);
 
     /* Unlock file descriptors */
     picotm_slist_walk_0(&self->fd_tx_active_list, unlock_fd_tx_cb);
@@ -2992,37 +2953,12 @@ validate_fd_tx_cb(struct picotm_slist* item, void* data)
     return validate_fd_tx(fd_tx_of_slist(item), data);
 }
 
-static size_t
-validate_ofd_tx(struct ofd_tx* ofd_tx, struct picotm_error* error)
-{
-    ofd_tx_validate(ofd_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-validate_ofd_tx_cb(struct picotm_slist* item, void* data)
-{
-    return validate_ofd_tx(ofd_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_validate(struct fildes_tx* self, int noundo,
                    struct picotm_error* error)
 {
     /* Validate file-descriptor state */
     picotm_slist_walk_1(&self->fd_tx_active_list, validate_fd_tx_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
-    /* Validate open file descriptions */
-    picotm_slist_walk_1(&self->ofd_tx_active_list, validate_ofd_tx_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
 }
 
 void

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -604,13 +604,10 @@ find_fd_tx_with_ref(struct fildes_tx* self, int fildes, int ofd_fildes,
     if (fd_tx_holds_ref(fd_tx)) {
 
         /* Validate reference or return error if fd has been closed */
-        fd_tx_lock(fd_tx);
         fd_tx_validate(fd_tx, error);
         if (picotm_error_is_set(error)) {
-            fd_tx_unlock(fd_tx);
             return NULL;
         }
-        fd_tx_unlock(fd_tx);
 
         return fd_tx;
     }
@@ -2894,48 +2891,6 @@ undo_write(struct fildes_tx* self, int fildes, int cookie,
 /*
  * Module interface
  */
-
-static size_t
-lock_fd_tx(struct fd_tx* fd_tx)
-{
-    fd_tx_lock(fd_tx);
-    return 1;
-}
-
-static size_t
-lock_fd_tx_cb(struct picotm_slist* item)
-{
-    return lock_fd_tx(fd_tx_of_slist(item));
-}
-
-void
-fildes_tx_lock(struct fildes_tx* self, struct picotm_error* error)
-{
-    /* Lock file descriptors */
-    picotm_slist_walk_0(&self->fd_tx_active_list, lock_fd_tx_cb);
-}
-
-static size_t
-unlock_fd_tx(struct fd_tx* fd_tx)
-{
-    fd_tx_unlock(fd_tx);
-    return 1;
-}
-
-static size_t
-unlock_fd_tx_cb(struct picotm_slist* item)
-{
-    return unlock_fd_tx(fd_tx_of_slist(item));
-}
-
-void
-fildes_tx_unlock(struct fildes_tx* self)
-{
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    /* Unlock file descriptors */
-    picotm_slist_walk_0(&self->fd_tx_active_list, unlock_fd_tx_cb);
-}
 
 static size_t
 validate_fd_tx(struct fd_tx* fd_tx, struct picotm_error* error)

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -2924,22 +2924,6 @@ lock_ofd_tx_cb(struct picotm_slist* item, void* data)
     return lock_ofd_tx(ofd_tx_of_slist(item), data);
 }
 
-static size_t
-lock_file_tx(struct file_tx* file_tx, struct picotm_error* error)
-{
-    file_tx_lock(file_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-lock_file_tx_cb(struct picotm_slist* item, void* data)
-{
-    return lock_file_tx(file_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_lock(struct fildes_tx* self, struct picotm_error* error)
 {
@@ -2948,12 +2932,6 @@ fildes_tx_lock(struct fildes_tx* self, struct picotm_error* error)
 
     /* Lock open file descriptions */
     picotm_slist_walk_1(&self->ofd_tx_active_list, lock_ofd_tx_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
-    /* Lock files */
-    picotm_slist_walk_1(&self->file_tx_active_list, lock_file_tx_cb, error);
     if (picotm_error_is_set(error)) {
         return;
     }
@@ -2986,27 +2964,10 @@ unlock_ofd_tx_cb(struct picotm_slist* item)
     return unlock_ofd_tx(ofd_tx_of_slist(item));
 }
 
-static size_t
-unlock_file_tx(struct file_tx* file_tx)
-{
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-    file_tx_unlock(file_tx, &error);
-    return 1;
-}
-
-static size_t
-unlock_file_tx_cb(struct picotm_slist* item)
-{
-    return unlock_file_tx(file_tx_of_slist(item));
-}
-
 void
 fildes_tx_unlock(struct fildes_tx* self)
 {
     struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-
-    /* Unlock files */
-    picotm_slist_walk_0(&self->file_tx_active_list, unlock_file_tx_cb);
 
     /* Unlock open file descriptions */
     picotm_slist_walk_0(&self->ofd_tx_active_list, unlock_ofd_tx_cb);
@@ -3047,22 +3008,6 @@ validate_ofd_tx_cb(struct picotm_slist* item, void* data)
     return validate_ofd_tx(ofd_tx_of_slist(item), data);
 }
 
-static size_t
-validate_file_tx(struct file_tx* file_tx, struct picotm_error* error)
-{
-    file_tx_validate(file_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-validate_file_tx_cb(struct picotm_slist* item, void* data)
-{
-    return validate_file_tx(file_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_validate(struct fildes_tx* self, int noundo,
                    struct picotm_error* error)
@@ -3075,13 +3020,6 @@ fildes_tx_validate(struct fildes_tx* self, int noundo,
 
     /* Validate open file descriptions */
     picotm_slist_walk_1(&self->ofd_tx_active_list, validate_ofd_tx_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
-    /* Validate files */
-    picotm_slist_walk_1(&self->file_tx_active_list, validate_file_tx_cb,
-                        error);
     if (picotm_error_is_set(error)) {
         return;
     }

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -2995,16 +2995,6 @@ fildes_tx_undo_event(struct fildes_tx* self, enum fildes_op op, int fildes,
     }
 }
 
-void
-fildes_tx_update_cc(struct fildes_tx* self, int noundo,
-                    struct picotm_error* error)
-{ }
-
-void
-fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
-                   struct picotm_error* error)
-{ }
-
 static void
 finish_file_tx(struct file_tx* file_tx)
 {

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -2995,32 +2995,10 @@ fildes_tx_undo_event(struct fildes_tx* self, enum fildes_op op, int fildes,
     }
 }
 
-static size_t
-update_fd_tx_cc(struct fd_tx* fd_tx, struct picotm_error* error)
-{
-    fd_tx_update_cc(fd_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-update_fd_tx_cc_cb(struct picotm_slist* item, void* data)
-{
-    return update_fd_tx_cc(fd_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_update_cc(struct fildes_tx* self, int noundo,
                     struct picotm_error* error)
 {
-    /* Update concurrency control on file descriptors */
-    picotm_slist_walk_1(&self->fd_tx_active_list, update_fd_tx_cc_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
     /* Update concurrency control on file-descriptor table */
     fdtab_tx_update_cc(&self->fdtab_tx, error);
     if (picotm_error_is_set(error)) {
@@ -3028,32 +3006,10 @@ fildes_tx_update_cc(struct fildes_tx* self, int noundo,
     }
 }
 
-static size_t
-clear_fd_tx_cc(struct fd_tx* fd_tx, struct picotm_error* error)
-{
-    fd_tx_clear_cc(fd_tx, error);
-    if (picotm_error_is_set(error)) {
-        return 0;
-    }
-    return 1;
-}
-
-static size_t
-clear_fd_tx_cc_cb(struct picotm_slist* item, void* data)
-{
-    return clear_fd_tx_cc(fd_tx_of_slist(item), data);
-}
-
 void
 fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
                    struct picotm_error* error)
 {
-    /* Clear concurrency control on file descriptors */
-    picotm_slist_walk_1(&self->fd_tx_active_list, clear_fd_tx_cc_cb, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
-
     /* Clear concurrency control on file-descriptor table */
 
     fdtab_tx_update_cc(&self->fdtab_tx, error);
@@ -3091,6 +3047,7 @@ finish_ofd_tx_cb(struct picotm_slist* item)
 static void
 finish_fd_tx(struct fd_tx* fd_tx)
 {
+    fd_tx_finish(fd_tx);
     fd_tx_unref(fd_tx);
 }
 

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -2893,9 +2893,9 @@ undo_write(struct fildes_tx* self, int fildes, int cookie,
  */
 
 static size_t
-validate_fd_tx(struct fd_tx* fd_tx, struct picotm_error* error)
+prepare_commit_fd_tx(struct fd_tx* fd_tx, struct picotm_error* error)
 {
-    fd_tx_validate(fd_tx, error);
+    fd_tx_prepare_commit(fd_tx, error);
     if (picotm_error_is_set(error)) {
         return 0;
     }
@@ -2903,17 +2903,18 @@ validate_fd_tx(struct fd_tx* fd_tx, struct picotm_error* error)
 }
 
 static size_t
-validate_fd_tx_cb(struct picotm_slist* item, void* data)
+prepare_commit_fd_tx_cb(struct picotm_slist* item, void* data)
 {
-    return validate_fd_tx(fd_tx_of_slist(item), data);
+    return prepare_commit_fd_tx(fd_tx_of_slist(item), data);
 }
 
 void
-fildes_tx_validate(struct fildes_tx* self, int noundo,
-                   struct picotm_error* error)
+fildes_tx_prepare_commit(struct fildes_tx* self, int noundo,
+                         struct picotm_error* error)
 {
     /* Validate file-descriptor state */
-    picotm_slist_walk_1(&self->fd_tx_active_list, validate_fd_tx_cb, error);
+    picotm_slist_walk_1(&self->fd_tx_active_list, prepare_commit_fd_tx_cb,
+                        error);
 }
 
 void

--- a/modules/libc/src/fildes/fildes_tx.h
+++ b/modules/libc/src/fildes/fildes_tx.h
@@ -245,12 +245,6 @@ fildes_tx_exec_write(struct fildes_tx* self, int fildes, const void* buf,
  */
 
 void
-fildes_tx_lock(struct fildes_tx* self, struct picotm_error* error);
-
-void
-fildes_tx_unlock(struct fildes_tx* self);
-
-void
 fildes_tx_validate(struct fildes_tx* self, int noundo,
                    struct picotm_error* error);
 

--- a/modules/libc/src/fildes/fildes_tx.h
+++ b/modules/libc/src/fildes/fildes_tx.h
@@ -257,12 +257,4 @@ fildes_tx_undo_event(struct fildes_tx* self, enum fildes_op op, int fildes,
                      int cookie, struct picotm_error* error);
 
 void
-fildes_tx_update_cc(struct fildes_tx* self, int noundo,
-                    struct picotm_error* error);
-
-void
-fildes_tx_clear_cc(struct fildes_tx* self, int noundo,
-                   struct picotm_error* error);
-
-void
 fildes_tx_finish(struct fildes_tx* self, struct picotm_error* error);

--- a/modules/libc/src/fildes/fildes_tx.h
+++ b/modules/libc/src/fildes/fildes_tx.h
@@ -245,8 +245,8 @@ fildes_tx_exec_write(struct fildes_tx* self, int fildes, const void* buf,
  */
 
 void
-fildes_tx_validate(struct fildes_tx* self, int noundo,
-                   struct picotm_error* error);
+fildes_tx_prepare_commit(struct fildes_tx* self, int noundo,
+                         struct picotm_error* error);
 
 void
 fildes_tx_apply_event(struct fildes_tx* self, enum fildes_op op, int fildes,

--- a/modules/libc/src/fildes/file_tx.c
+++ b/modules/libc/src/fildes/file_tx.c
@@ -73,21 +73,11 @@ file_tx_unref(struct file_tx* self)
  */
 
 void
-file_tx_update_cc(struct file_tx* self, struct picotm_error* error)
+file_tx_finish(struct file_tx* self)
 {
     assert(self);
     assert(self->ops);
-    assert(self->ops->update_cc);
+    assert(self->ops->finish);
 
-    self->ops->update_cc(self, error);
-}
-
-void
-file_tx_clear_cc(struct file_tx* self, struct picotm_error* error)
-{
-    assert(self);
-    assert(self->ops);
-    assert(self->ops->clear_cc);
-
-    self->ops->clear_cc(self, error);
+    self->ops->finish(self);
 }

--- a/modules/libc/src/fildes/file_tx.c
+++ b/modules/libc/src/fildes/file_tx.c
@@ -73,36 +73,6 @@ file_tx_unref(struct file_tx* self)
  */
 
 void
-file_tx_lock(struct file_tx* self, struct picotm_error* error)
-{
-    assert(self);
-    assert(self->ops);
-    assert(self->ops->lock);
-
-    self->ops->lock(self, error);
-}
-
-void
-file_tx_unlock(struct file_tx* self, struct picotm_error* error)
-{
-    assert(self);
-    assert(self->ops);
-    assert(self->ops->unlock);
-
-    self->ops->unlock(self, error);
-}
-
-void
-file_tx_validate(struct file_tx* self, struct picotm_error* error)
-{
-    assert(self);
-    assert(self->ops);
-    assert(self->ops->validate);
-
-    self->ops->validate(self, error);
-}
-
-void
 file_tx_update_cc(struct file_tx* self, struct picotm_error* error)
 {
     assert(self);

--- a/modules/libc/src/fildes/file_tx.h
+++ b/modules/libc/src/fildes/file_tx.h
@@ -97,19 +97,9 @@ file_tx_unref(struct file_tx* self);
  */
 
 /**
- * \brief Updates the concurrency control on transaction-local file state
- *        after a successful apply.
- * \param       self    The transaction-local file state.
- * \param[out]  error   Returns an error to the caller.
+ * \brief Finishes the transaction-local file state at the end of a
+ *        transaction.
+ * \param   self    The transaction-local file state.
  */
 void
-file_tx_update_cc(struct file_tx* self, struct picotm_error* error);
-
-/**
- * \brief Clears the concurrency control on transaction-local file state
- *        after a successful apply.
- * \param       self    The transaction-local file state.
- * \param[out]  error   Returns an error to the caller.
- */
-void
-file_tx_clear_cc(struct file_tx* self, struct picotm_error* error);
+file_tx_finish(struct file_tx* self);

--- a/modules/libc/src/fildes/file_tx.h
+++ b/modules/libc/src/fildes/file_tx.h
@@ -97,30 +97,6 @@ file_tx_unref(struct file_tx* self);
  */
 
 /**
- * Locks the transaction-local file state before commit or validation.
- * \param   self        The transaction-local file state.
- * \param[out]  error   Returns an error to the caller.
- */
-void
-file_tx_lock(struct file_tx* self, struct picotm_error* error);
-
-/**
- * Unlocks the transaction-local file state after commit or validation.
- * \param   self        The transaction-local file state.
- * \param[out]  error   Returns an error to the caller.
- */
-void
-file_tx_unlock(struct file_tx* self, struct picotm_error* error);
-
-/**
- * Validates the transaction-local file state.
- * \param       self    The transaction-local file state.
- * \param[out]  error   Returns an error to the caller.
- */
-void
-file_tx_validate(struct file_tx* self, struct picotm_error* error);
-
-/**
  * \brief Updates the concurrency control on transaction-local file state
  *        after a successful apply.
  * \param       self    The transaction-local file state.

--- a/modules/libc/src/fildes/file_tx_ops.h
+++ b/modules/libc/src/fildes/file_tx_ops.h
@@ -63,9 +63,6 @@ struct file_tx_ops {
      * Module interfaces
      */
 
-    void (*lock)(struct file_tx*, struct picotm_error*);
-    void (*unlock)(struct file_tx*, struct picotm_error*);
-    void (*validate)(struct file_tx*, struct picotm_error*r);
     void (*update_cc)(struct file_tx*, struct picotm_error*);
     void (*clear_cc)(struct file_tx*, struct picotm_error*);
 

--- a/modules/libc/src/fildes/file_tx_ops.h
+++ b/modules/libc/src/fildes/file_tx_ops.h
@@ -63,8 +63,7 @@ struct file_tx_ops {
      * Module interfaces
      */
 
-    void (*update_cc)(struct file_tx*, struct picotm_error*);
-    void (*clear_cc)(struct file_tx*, struct picotm_error*);
+    void (*finish)(struct file_tx*);
 
     /*
      * accept()

--- a/modules/libc/src/fildes/module.c
+++ b/modules/libc/src/fildes/module.c
@@ -39,7 +39,7 @@ struct fildes_module {
 };
 
 static void
-validate_cb(void* data, int noundo, struct picotm_error* error)
+prepare_commit_cb(void* data, int noundo, struct picotm_error* error)
 {
     struct fildes_module* module = data;
 
@@ -110,7 +110,7 @@ static struct fildes_tx*
 get_fildes_tx(bool initialize, struct picotm_error* error)
 {
     static const struct picotm_module_ops g_ops = {
-        .validate = validate_cb,
+        .prepare_commit = prepare_commit_cb,
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,
         .update_cc = update_cc_cb,

--- a/modules/libc/src/fildes/module.c
+++ b/modules/libc/src/fildes/module.c
@@ -71,22 +71,6 @@ undo_event_cb(uint16_t head, uintptr_t tail, void *data,
 }
 
 static void
-update_cc_cb(void* data, int noundo, struct picotm_error* error)
-{
-    struct fildes_module* module = data;
-
-    fildes_tx_update_cc(&module->tx, noundo, error);
-}
-
-static void
-clear_cc_cb(void* data, int noundo, struct picotm_error* error)
-{
-    struct fildes_module* module = data;
-
-    fildes_tx_clear_cc(&module->tx, noundo, error);
-}
-
-static void
 finish_cb(void* data, struct picotm_error* error)
 {
     struct fildes_module* module = data;
@@ -113,8 +97,6 @@ get_fildes_tx(bool initialize, struct picotm_error* error)
         .prepare_commit = prepare_commit_cb,
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,
-        .update_cc = update_cc_cb,
-        .clear_cc = clear_cc_cb,
         .finish = finish_cb,
         .uninit = uninit_cb
     };

--- a/modules/libc/src/fildes/module.c
+++ b/modules/libc/src/fildes/module.c
@@ -43,7 +43,7 @@ validate_cb(void* data, int noundo, struct picotm_error* error)
 {
     struct fildes_module* module = data;
 
-    fildes_tx_validate(&module->tx, noundo, error);
+    fildes_tx_prepare_commit(&module->tx, noundo, error);
 }
 
 static void

--- a/modules/libc/src/fildes/module.c
+++ b/modules/libc/src/fildes/module.c
@@ -39,22 +39,6 @@ struct fildes_module {
 };
 
 static void
-lock_cb(void* data, struct picotm_error* error)
-{
-    struct fildes_module* module = data;
-
-    fildes_tx_lock(&module->tx, error);
-}
-
-static void
-unlock_cb(void* data, struct picotm_error* error)
-{
-    struct fildes_module* module = data;
-
-    fildes_tx_unlock(&module->tx);
-}
-
-static void
 validate_cb(void* data, int noundo, struct picotm_error* error)
 {
     struct fildes_module* module = data;
@@ -126,8 +110,6 @@ static struct fildes_tx*
 get_fildes_tx(bool initialize, struct picotm_error* error)
 {
     static const struct picotm_module_ops g_ops = {
-        .lock = lock_cb,
-        .unlock = unlock_cb,
         .validate = validate_cb,
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,

--- a/modules/libc/src/fildes/ofd_tx.c
+++ b/modules/libc/src/fildes/ofd_tx.c
@@ -254,28 +254,6 @@ ofd_tx_try_wrlock_field(struct ofd_tx* self, enum ofd_field field,
  */
 
 void
-ofd_tx_lock(struct ofd_tx* self, struct picotm_error* error)
-{
-    assert(self);
-}
-
-void
-ofd_tx_unlock(struct ofd_tx* self, struct picotm_error* error)
-{
-    assert(self);
-}
-
-void
-ofd_tx_validate(struct ofd_tx* self, struct picotm_error* error)
-{
-    /* Locked regions are ours, so we do not need to validate here. All
-     * conflicting transactions will have aborted on encountering our locks.
-     *
-     * The state of the OFD itself is guarded by ofd::rwlock.
-     */
-}
-
-void
 ofd_tx_update_cc(struct ofd_tx* self, struct picotm_error* error)
 {
     assert(self);

--- a/modules/libc/src/fildes/ofd_tx.c
+++ b/modules/libc/src/fildes/ofd_tx.c
@@ -254,18 +254,7 @@ ofd_tx_try_wrlock_field(struct ofd_tx* self, enum ofd_field field,
  */
 
 void
-ofd_tx_update_cc(struct ofd_tx* self, struct picotm_error* error)
-{
-    assert(self);
-
-    /* release reader/writer locks on open-file-description state */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->ofd);
-}
-
-void
-ofd_tx_clear_cc(struct ofd_tx* self, struct picotm_error* error)
+ofd_tx_finish(struct ofd_tx* self)
 {
     assert(self);
 

--- a/modules/libc/src/fildes/ofd_tx.h
+++ b/modules/libc/src/fildes/ofd_tx.h
@@ -222,24 +222,6 @@ ofd_tx_try_wrlock_field(struct ofd_tx* self, enum ofd_field field,
  */
 
 /**
- * Prepares the open file description for commit
- */
-void
-ofd_tx_lock(struct ofd_tx* self, struct picotm_error* error);
-
-/**
- * Finishes commit for open file description
- */
-void
-ofd_tx_unlock(struct ofd_tx* self, struct picotm_error* error);
-
-/**
- * Validate the local state
- */
-void
-ofd_tx_validate(struct ofd_tx* self, struct picotm_error* error);
-
-/**
  * Updates the data structures for concurrency control after a successful apply
  */
 void

--- a/modules/libc/src/fildes/ofd_tx.h
+++ b/modules/libc/src/fildes/ofd_tx.h
@@ -217,18 +217,13 @@ ofd_tx_try_rdlock_field(struct ofd_tx* self, enum ofd_field field,
 void
 ofd_tx_try_wrlock_field(struct ofd_tx* self, enum ofd_field field,
                         struct picotm_error* error);
+
 /*
  * Module interface
  */
 
 /**
- * Updates the data structures for concurrency control after a successful apply
+ * Cleans up the data structures for at the end of a transaction.
  */
 void
-ofd_tx_update_cc(struct ofd_tx* self, struct picotm_error* error);
-
-/**
- * Clears the data structures for concurrency control after a successful undo
- */
-void
-ofd_tx_clear_cc(struct ofd_tx* self, struct picotm_error* error);
+ofd_tx_finish(struct ofd_tx* self);

--- a/modules/libc/src/fildes/regfile_tx.c
+++ b/modules/libc/src/fildes/regfile_tx.c
@@ -1049,28 +1049,8 @@ write_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Public interface
  */
 
-/* Update CC
- */
-
 static void
-update_cc(struct file_tx* base, struct picotm_error* error)
-{
-    struct regfile_tx* self = regfile_tx_of_file_tx(base);
-
-    /* release record locks */
-    regfile_tx_2pl_release_locks(self);
-
-    /* release reader/writer locks on file state */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->regfile);
-}
-
-/* Clear CC
- */
-
-static void
-clear_cc(struct file_tx* base, struct picotm_error* error)
+finish(struct file_tx* base)
 {
     struct regfile_tx* self = regfile_tx_of_file_tx(base);
 
@@ -1093,8 +1073,7 @@ static const struct file_tx_ops regfile_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    update_cc,
-    clear_cc,
+    finish,
     /* file ops */
     file_tx_op_accept_exec_enotsock,
     NULL,

--- a/modules/libc/src/fildes/regfile_tx.c
+++ b/modules/libc/src/fildes/regfile_tx.c
@@ -1049,27 +1049,6 @@ write_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Public interface
  */
 
-static void
-lock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-static void
-unlock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-/* Validation
- */
-
-static void
-validate(struct file_tx* base, struct picotm_error* error)
-{
-    /* Locked regions are ours, so we do not need to validate here. All
-     * conflicting transactions will have aborted on encountering our locks.
-     *
-     * The state of the OFD itself is guarded by regfile::rwlock.
-     */
-}
-
 /* Update CC
  */
 
@@ -1114,9 +1093,6 @@ static const struct file_tx_ops regfile_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    lock,
-    unlock,
-    validate,
     update_cc,
     clear_cc,
     /* file ops */

--- a/modules/libc/src/fildes/socket_tx.c
+++ b/modules/libc/src/fildes/socket_tx.c
@@ -694,21 +694,6 @@ write_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Public interface
  */
 
-static void
-lock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-static void
-unlock(struct file_tx* base, struct picotm_error* error)
-{ }
-
-/* Validation
- */
-
-static void
-validate(struct file_tx* base, struct picotm_error* error)
-{ }
-
 /* Update CC
  */
 
@@ -747,9 +732,6 @@ static const struct file_tx_ops socket_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    lock,
-    unlock,
-    validate,
     update_cc,
     clear_cc,
     /* file ops */

--- a/modules/libc/src/fildes/socket_tx.c
+++ b/modules/libc/src/fildes/socket_tx.c
@@ -694,25 +694,8 @@ write_apply(struct file_tx* base, struct ofd_tx* ofd_tx, int fildes,
  * Public interface
  */
 
-/* Update CC
- */
-
 static void
-update_cc(struct file_tx* base, struct picotm_error* error)
-{
-    struct socket_tx* self = socket_tx_of_file_tx(base);
-
-    /* release reader/writer locks on socket state */
-    unlock_rwstates(picotm_arraybeg(self->rwstate),
-                    picotm_arrayend(self->rwstate),
-                    self->socket);
-}
-
-/* Clear CC
- */
-
-static void
-clear_cc(struct file_tx* base, struct picotm_error* error)
+finish(struct file_tx* base)
 {
     struct socket_tx* self = socket_tx_of_file_tx(base);
 
@@ -732,8 +715,7 @@ static const struct file_tx_ops socket_tx_ops = {
     ref,
     unref,
     /* module interfaces */
-    update_cc,
-    clear_cc,
+    finish,
     /* file ops */
     accept_exec,
     file_tx_op_apply,

--- a/modules/tm/src/module.c
+++ b/modules/tm/src/module.c
@@ -91,24 +91,6 @@ struct tm_module {
 };
 
 static void
-lock(struct tm_module* module, struct picotm_error* error)
-{
-    tm_vmem_tx_lock(&module->tx, error);
-}
-
-static void
-unlock(struct tm_module* module, struct picotm_error* error)
-{
-    tm_vmem_tx_unlock(&module->tx, error);
-}
-
-static void
-validate(struct tm_module* module, bool eotx, struct picotm_error* error)
-{
-    tm_vmem_tx_validate(&module->tx, eotx, error);
-}
-
-static void
 apply(struct tm_module* module, struct picotm_error* error)
 {
     tm_vmem_tx_apply(&module->tx, error);
@@ -138,24 +120,6 @@ uninit(struct tm_module* module)
  */
 
 static void
-lock_cb(void* data, struct picotm_error* error)
-{
-    lock(data, error);
-}
-
-static void
-unlock_cb(void* data, struct picotm_error* error)
-{
-    unlock(data, error);
-}
-
-static void
-validate_cb(void* data, int eotx, struct picotm_error* error)
-{
-    validate(data, !!eotx, error);
-}
-
-static void
 apply_cb(void* data, struct picotm_error* error)
 {
     apply(data, error);
@@ -183,9 +147,6 @@ static struct tm_vmem_tx*
 get_vmem_tx(bool initialize, struct picotm_error* error)
 {
     static const struct picotm_module_ops g_ops = {
-        .lock = lock_cb,
-        .unlock = unlock_cb,
-        .validate = validate_cb,
         .apply = apply_cb,
         .undo = undo_cb,
         .finish = finish_cb,

--- a/modules/tm/src/vmem_tx.c
+++ b/modules/tm/src/vmem_tx.c
@@ -567,26 +567,6 @@ tm_vmem_tx_privatize_c(struct tm_vmem_tx* vmem_tx, uintptr_t addr, int c,
     }
 }
 
-void
-tm_vmem_tx_lock(struct tm_vmem_tx* vmem_tx, struct picotm_error* error)
-{
-    /* We've already locked all frames. */
-}
-
-void
-tm_vmem_tx_unlock(struct tm_vmem_tx* vmem_tx, struct picotm_error* error)
-{
-    /* The lock() function is a NO-OP, so this is as well. */
-}
-
-void
-tm_vmem_tx_validate(struct tm_vmem_tx* vmem_tx, bool eotx,
-                    struct picotm_error* error)
-{
-    /* We've locked all frames during execution phase, so we
-     * already know that they are in a consistent state. */
-}
-
 static size_t
 apply_page(struct tm_page* page, struct tm_vmem* vmem, struct picotm_error* error)
 {

--- a/modules/tm/src/vmem_tx.h
+++ b/modules/tm/src/vmem_tx.h
@@ -107,25 +107,6 @@ tm_vmem_tx_privatize_c(struct tm_vmem_tx* vmem_tx, uintptr_t addr, int c,
                        unsigned long flags, struct picotm_error* error);
 
 /**
- * Acquires exclusive access to the frames of this transaction.
- */
-void
-tm_vmem_tx_lock(struct tm_vmem_tx* vmem_tx, struct picotm_error* error);
-
-/**
- * Releases exclusive access.
- */
-void
-tm_vmem_tx_unlock(struct tm_vmem_tx* vmem_tx, struct picotm_error* error);
-
-/**
- * Validates consistency of the transactions state.
- */
-void
-tm_vmem_tx_validate(struct tm_vmem_tx* vmem_tx, bool eotx,
-                    struct picotm_error* error);
-
-/**
  * Applies all transaction-local changes to main memory.
  */
 void

--- a/modules/txlib/src/txlib_module.c
+++ b/modules/txlib/src/txlib_module.c
@@ -51,7 +51,7 @@ struct txlib_module {
 static void
 lock(struct txlib_module* module, struct picotm_error* error)
 {
-    txlib_tx_lock(&module->tx, error);
+    txlib_tx_prepare_commit(&module->tx, error);
 }
 
 static void

--- a/modules/txlib/src/txlib_module.c
+++ b/modules/txlib/src/txlib_module.c
@@ -49,7 +49,7 @@ struct txlib_module {
 };
 
 static void
-lock(struct txlib_module* module, struct picotm_error* error)
+prepare_commit(struct txlib_module* module, struct picotm_error* error)
 {
     txlib_tx_prepare_commit(&module->tx, error);
 }
@@ -86,9 +86,9 @@ uninit(struct txlib_module* module)
  */
 
 static void
-lock_cb(void* data, struct picotm_error* error)
+prepare_commit_cb(void* data, int is_irrevocable, struct picotm_error* error)
 {
-    lock(data, error);
+    prepare_commit(data, error);
 }
 
 static void
@@ -121,7 +121,7 @@ static struct txlib_tx*
 get_txl_tx(bool initialize, struct picotm_error* error)
 {
     static const struct picotm_module_ops g_ops = {
-        .lock = lock_cb,
+        .prepare_commit = prepare_commit_cb,
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,
         .finish = finish_cb,

--- a/modules/txlib/src/txlib_tx.c
+++ b/modules/txlib/src/txlib_tx.c
@@ -406,7 +406,7 @@ lock_txstack_tx_entries(struct txlib_tx* self, struct picotm_error* error)
 }
 
 void
-txlib_tx_lock(struct txlib_tx* self, struct picotm_error* error)
+txlib_tx_prepare_commit(struct txlib_tx* self, struct picotm_error* error)
 {
     /* Currently, no locking is required for lists and multisets. Both
      * data structures acquire their locks during the transaction's

--- a/modules/txlib/src/txlib_tx.h
+++ b/modules/txlib/src/txlib_tx.h
@@ -195,7 +195,7 @@ txlib_tx_append_events3(struct txlib_tx* self, size_t nevents,
  */
 
 void
-txlib_tx_lock(struct txlib_tx* self, struct picotm_error* error);
+txlib_tx_prepare_commit(struct txlib_tx* self, struct picotm_error* error);
 
 void
 txlib_tx_apply_event(struct txlib_tx* self,

--- a/src/picotm.c
+++ b/src/picotm.c
@@ -420,13 +420,6 @@ picotm_restart()
 }
 
 PICOTM_EXPORT
-bool
-picotm_is_valid()
-{
-    return picotm_tx_is_valid(get_non_null_tx());
-}
-
-PICOTM_EXPORT
 void
 picotm_irrevocable()
 {

--- a/src/picotm_module.c
+++ b/src/picotm_module.c
@@ -71,42 +71,16 @@ picotm_module_begin(const struct picotm_module* self,
 }
 
 void
-picotm_module_lock(const struct picotm_module* self,
-                   struct picotm_error* error)
+picotm_module_prepare_commit(const struct picotm_module* self, bool noundo,
+                             struct picotm_error* error)
 {
     assert(self);
     assert(self->ops);
 
-    if (!self->ops->lock) {
+    if (!self->ops->prepare_commit) {
         return;
     }
-    self->ops->lock(self->data, error);
-}
-
-void
-picotm_module_unlock(const struct picotm_module* self,
-                     struct picotm_error* error)
-{
-    assert(self);
-    assert(self->ops);
-
-    if (!self->ops->unlock) {
-        return;
-    }
-    self->ops->unlock(self->data, error);
-}
-
-void
-picotm_module_validate(const struct picotm_module* self, bool noundo,
-                       struct picotm_error* error)
-{
-    assert(self);
-    assert(self->ops);
-
-    if (!self->ops->validate) {
-        return;
-    }
-    self->ops->validate(self->data, noundo, error);
+    self->ops->prepare_commit(self->data, noundo, error);
 }
 
 void

--- a/src/picotm_module.c
+++ b/src/picotm_module.c
@@ -138,32 +138,6 @@ picotm_module_undo_event(const struct picotm_module* self,
 }
 
 void
-picotm_module_update_cc(const struct picotm_module* self, bool noundo,
-                        struct picotm_error* error)
-{
-    assert(self);
-    assert(self->ops);
-
-    if (!self->ops->update_cc) {
-        return;
-    }
-    self->ops->update_cc(self->data, noundo, error);
-}
-
-void
-picotm_module_clear_cc(const struct picotm_module* self, bool noundo,
-                       struct picotm_error* error)
-{
-    assert(self);
-    assert(self->ops);
-
-    if (!self->ops->clear_cc) {
-        return;
-    }
-    self->ops->clear_cc(self->data, noundo, error);
-}
-
-void
 picotm_module_finish(const struct picotm_module* self,
                      struct picotm_error* error)
 {

--- a/src/picotm_module.h
+++ b/src/picotm_module.h
@@ -82,13 +82,5 @@ picotm_module_undo_event(const struct picotm_module* self,
                          struct picotm_error* error);
 
 void
-picotm_module_update_cc(const struct picotm_module* self, bool noundo,
-                        struct picotm_error* error);
-
-void
-picotm_module_clear_cc(const struct picotm_module* self, bool noundo,
-                       struct picotm_error* error);
-
-void
 picotm_module_finish(const struct picotm_module* self,
                      struct picotm_error* error);

--- a/src/picotm_module.h
+++ b/src/picotm_module.h
@@ -60,16 +60,8 @@ picotm_module_begin(const struct picotm_module* self,
                     struct picotm_error* error);
 
 void
-picotm_module_lock(const struct picotm_module* self,
-                   struct picotm_error* error);
-
-void
-picotm_module_unlock(const struct picotm_module* self,
-                     struct picotm_error* error);
-
-void
-picotm_module_validate(const struct picotm_module* self, bool noundo,
-                       struct picotm_error* error);
+picotm_module_prepare_commit(const struct picotm_module* self, bool noundo,
+                             struct picotm_error* error);
 
 void
 picotm_module_apply(const struct picotm_module* self,

--- a/src/picotm_tx.c
+++ b/src/picotm_tx.c
@@ -540,18 +540,3 @@ err:
     picotm_error_mark_as_non_recoverable(error);
     picotm_lock_manager_release_irrevocability(self->lm);
 }
-
-bool
-picotm_tx_is_valid(struct picotm_tx* self)
-{
-    assert(self);
-
-    struct picotm_error error = PICOTM_ERROR_INITIALIZER;
-    validate_modules(self->module, self->nmodules,
-                     picotm_tx_is_irrevocable(self),
-                     &error);
-    if (picotm_error_is_set(&error)) {
-        return false;
-    }
-    return true;
-}

--- a/src/picotm_tx.h
+++ b/src/picotm_tx.h
@@ -94,6 +94,3 @@ picotm_tx_commit(struct picotm_tx* self, struct picotm_error* error);
 
 void
 picotm_tx_rollback(struct picotm_tx* self, struct picotm_error* error);
-
-bool
-picotm_tx_is_valid(struct picotm_tx* self);


### PR DESCRIPTION
The module ops contain unnecessary function pointers. The structure and it's users should be cleaned up. Additionally, this prepares for 2PC. (#99)