### PR TITLE
Separate file-state tables from implementation

### DIFF
--- a/modules/libc/src/fildes/fdtab.c
+++ b/modules/libc/src/fildes/fdtab.c
@@ -47,37 +47,29 @@ struct fildes_fdtab {
     .lock = PICOTM_RWLOCK_INITIALIZER       \
 }
 
-static struct fildes_fdtab fdtab = FILDES_FDTAB_INITIALIZER;
-
-/* Destructor */
-
-static void fdtab_uninit(void) __attribute__((destructor));
-
 static size_t
-fdtab_fd_uninit_walk(void* fd, struct picotm_error* error)
+fd_uninit_walk_cb(void* fd, struct picotm_error* error)
 {
     fd_uninit(fd);
     return 1;
 }
 
 static void
-fdtab_uninit(void)
+fildes_fdtab_uninit(struct fildes_fdtab* self)
 {
     struct picotm_error error = PICOTM_ERROR_INITIALIZER;
 
-    picotm_tabwalk_1(fdtab.tab, picotm_arraylen(fdtab.tab),
-                     sizeof(fdtab.tab[0]), fdtab_fd_uninit_walk,
+    picotm_tabwalk_1(self->tab, picotm_arraylen(self->tab),
+                     sizeof(self->tab[0]), fd_uninit_walk_cb,
                      &error);
 
-    pthread_rwlock_destroy(&fdtab.rwlock);
+    pthread_rwlock_destroy(&self->rwlock);
 }
 
-/* End of destructor */
-
 static void
-rdlock_fdtab(struct picotm_error* error)
+rdlock_fdtab(struct fildes_fdtab* fdtab, struct picotm_error* error)
 {
-    int err = pthread_rwlock_rdlock(&fdtab.rwlock);
+    int err = pthread_rwlock_rdlock(&fdtab->rwlock);
     if (err) {
         picotm_error_set_errno(error, err);
         return;
@@ -85,9 +77,9 @@ rdlock_fdtab(struct picotm_error* error)
 }
 
 static void
-wrlock_fdtab(struct picotm_error* error)
+wrlock_fdtab(struct fildes_fdtab* fdtab, struct picotm_error* error)
 {
-    int err = pthread_rwlock_wrlock(&fdtab.rwlock);
+    int err = pthread_rwlock_wrlock(&fdtab->rwlock);
     if (err) {
         picotm_error_set_errno(error, err);
         return;
@@ -95,10 +87,10 @@ wrlock_fdtab(struct picotm_error* error)
 }
 
 static void
-unlock_fdtab(void)
+unlock_fdtab(struct fildes_fdtab* fdtab)
 {
     do {
-        int err = pthread_rwlock_unlock(&fdtab.rwlock);
+        int err = pthread_rwlock_unlock(&fdtab->rwlock);
         if (err) {
             struct picotm_error error = PICOTM_ERROR_INITIALIZER;
             picotm_error_set_errno(&error, err);
@@ -112,13 +104,13 @@ unlock_fdtab(void)
 
 /* requires reader lock */
 static struct fd*
-find_by_id(int fildes, struct picotm_error* error)
+find_by_id(struct fildes_fdtab* fdtab, int fildes, struct picotm_error* error)
 {
-    if (fdtab.len <= (size_t)fildes) {
+    if (fdtab->len <= (size_t)fildes) {
         return NULL;
     }
 
-    struct fd* fd = fdtab.tab + fildes;
+    struct fd* fd = fdtab->tab + fildes;
 
     fd_ref_or_set_up(fd, fildes, error);
     if (picotm_error_is_set(error)) {
@@ -130,10 +122,11 @@ find_by_id(int fildes, struct picotm_error* error)
 
 /* requires writer lock */
 static struct fd*
-search_by_id(int fildes, struct picotm_error* error)
+search_by_id(struct fildes_fdtab* fdtab, int fildes,
+             struct picotm_error* error)
 {
-    struct fd* fd_beg = picotm_arrayat(fdtab.tab, fdtab.len);
-    const struct fd* fd_end = picotm_arrayat(fdtab.tab, fildes + 1);
+    struct fd* fd_beg = picotm_arrayat(fdtab->tab, fdtab->len);
+    const struct fd* fd_end = picotm_arrayat(fdtab->tab, fildes + 1);
 
     while (fd_beg < fd_end) {
 
@@ -142,11 +135,11 @@ search_by_id(int fildes, struct picotm_error* error)
             return NULL;
         }
 
-        ++fdtab.len;
+        ++fdtab->len;
         ++fd_beg;
     }
 
-    struct fd* fd = fdtab.tab + fildes;
+    struct fd* fd = fdtab->tab + fildes;
 
     fd_ref_or_set_up(fd, fildes, error);
     if (picotm_error_is_set(error)) {
@@ -157,75 +150,124 @@ search_by_id(int fildes, struct picotm_error* error)
 }
 
 struct fd*
-fdtab_ref_fildes(int fildes, struct picotm_rwstate* lock_state,
-                 struct picotm_error* error)
+fildes_fdtab_ref_fildes(struct fildes_fdtab* self, int fildes,
+                        struct picotm_rwstate* lock_state,
+                        struct picotm_error* error)
 {
     /* Try to find an existing fd structure with the given file
      * descriptor.
      */
 
-    rdlock_fdtab(error);
+    rdlock_fdtab(self, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
 
-    struct fd* fd = find_by_id(fildes, error);
+    struct fd* fd = find_by_id(self, fildes, error);
     if (picotm_error_is_set(error)) {
         goto err_find_by_id;
     } else if (fd) {
         goto unlock; /* found fd for fildes; return */
     }
 
-    unlock_fdtab();
+    unlock_fdtab(self);
 
     /* Not found; acquire writer lock to create a new entry
      * in the file-descriptor table.
      */
 
-    wrlock_fdtab(error);
+    wrlock_fdtab(self, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
 
-    fd = search_by_id(fildes, error);
+    fd = search_by_id(self, fildes, error);
     if (picotm_error_is_set(error)) {
         goto err_search_by_id;
         return NULL;
     }
 
 unlock:
-    unlock_fdtab();
+    unlock_fdtab(self);
 
     return fd;
 
 err_search_by_id:
 err_find_by_id:
-    unlock_fdtab();
+    unlock_fdtab(self);
     return NULL;
+}
+
+struct fd*
+fildes_fdtab_get_fd(struct fildes_fdtab* self, int fildes)
+{
+    return self->tab + fildes;
+}
+
+void
+fildes_fdtab_try_rdlock(struct fildes_fdtab* self,
+                        struct picotm_rwstate* lock_state,
+                        struct picotm_error* error)
+{
+    picotm_rwstate_try_rdlock(lock_state, &self->lock, error);
+}
+
+void
+fildes_fdtab_try_wrlock(struct fildes_fdtab* self,
+                        struct picotm_rwstate* lock_state,
+                        struct picotm_error* error)
+{
+    picotm_rwstate_try_wrlock(lock_state, &self->lock, error);
+}
+
+void
+fildes_fdtab_unlock(struct fildes_fdtab* self,
+                    struct picotm_rwstate* lock_state)
+{
+    picotm_rwstate_unlock(lock_state, &self->lock);
+}
+
+/*
+ * Global state
+ */
+
+static struct fildes_fdtab fdtab = FILDES_FDTAB_INITIALIZER;
+
+static __attribute__((destructor)) void
+fdtab_uninit(void)
+{
+    fildes_fdtab_uninit(&fdtab);
+}
+
+struct fd*
+fdtab_ref_fildes(int fildes, struct picotm_rwstate* lock_state,
+                 struct picotm_error* error)
+{
+    return fildes_fdtab_ref_fildes(&fdtab, fildes, lock_state, error);
 }
 
 struct fd*
 fdtab_get_fd(int fildes)
 {
-    return fdtab.tab + fildes;
+    return fildes_fdtab_get_fd(&fdtab, fildes);
 }
 
 void
 fdtab_try_rdlock(struct picotm_rwstate* lock_state,
                  struct picotm_error* error)
 {
-    picotm_rwstate_try_rdlock(lock_state, &fdtab.lock, error);
+    fildes_fdtab_try_rdlock(&fdtab, lock_state, error);
 }
 
 void
 fdtab_try_wrlock(struct picotm_rwstate* lock_state,
                  struct picotm_error* error)
 {
-    picotm_rwstate_try_wrlock(lock_state, &fdtab.lock, error);
+    fildes_fdtab_try_wrlock(&fdtab, lock_state, error);
 }
 
 void
 fdtab_unlock(struct picotm_rwstate* lock_state)
 {
-    picotm_rwstate_unlock(lock_state, &fdtab.lock);
+    fildes_fdtab_unlock(&fdtab, lock_state);
 }


### PR DESCRIPTION
File state should not be maintained in global strcutures (as it is now). This patch set prepares this change by separating the state data from the implementation.