### PR TITLE
Shared-state helpers

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -31,8 +31,9 @@ nobase_include_HEADERS = picotm/compiler.h \
                          picotm/picotm-lib-ref.h \
                          picotm/picotm-lib-rwlock.h \
                          picotm/picotm-lib-rwstate.h \
-                         picotm/picotm-lib-shared-treemap.h \
                          picotm/picotm-lib-shared-ref-obj.h \
+                         picotm/picotm-lib-shared-state.h \
+                         picotm/picotm-lib-shared-treemap.h \
                          picotm/picotm-lib-slist.h \
                          picotm/picotm-lib-spinlock.h \
                          picotm/picotm-lib-tab.h \

--- a/include/picotm/picotm-lib-global-state.h
+++ b/include/picotm/picotm-lib-global-state.h
@@ -79,8 +79,7 @@
  * ~~~{.c}
  *  struct picotm_error error = PICOTM_ERROR_INITIALIZER;
  *
- *  PICOTM_SHARED_STATE_TYPE(shared)* state =
- *      PICOTM_GLOBAL_STATE_REF(shared, &error);
+ *  struct shared* state = PICOTM_GLOBAL_STATE_REF(shared, &error);
  *  if (picotm_error_is_set(&error)) {
  *      // perform error handling
  *  }
@@ -126,7 +125,7 @@ struct picotm_error;
 /**
  * \warning This is an internal interface. Don't use it in application code.
  */
-#define __PICOTM_GLOBAL_STATE_IMPL(_static, _name)                  \
+#define __PICOTM_GLOBAL_STATE_IMPL(_static, _name, _type)           \
     _static PICOTM_SHARED_STATE_TYPE(_name)*                        \
     __PICOTM_GLOBAL_STATE_GET(_name)(void)                          \
     {                                                               \
@@ -134,7 +133,7 @@ struct picotm_error;
             PICOTM_SHARED_STATE_INITIALIZER;                        \
         return &s_global;                                           \
     }                                                               \
-    _static PICOTM_SHARED_STATE_TYPE(_name)*                        \
+    _static _type*                                                  \
     __PICOTM_GLOBAL_STATE_REF(_name)(struct picotm_error* error)    \
     {                                                               \
         PICOTM_SHARED_STATE_TYPE(_name)* global =                   \
@@ -153,24 +152,27 @@ struct picotm_error;
  * \ingroup group_lib
  * Expands to the implementation of a global state.
  * \param   _name   The state name.
+ * \param   _type   The state type.
  */
-#define PICOTM_GLOBAL_STATE_STATIC_IMPL(_name)  \
-    __PICOTM_GLOBAL_STATE_IMPL(static, _name)
+#define PICOTM_GLOBAL_STATE_STATIC_IMPL(_name, _type)   \
+    __PICOTM_GLOBAL_STATE_IMPL(static, _name, _type)
 
 /**
  * \ingroup group_lib
  * Returns the statically allocated global state. Callers *must* already
  * hold a reference.
  * \param   _name   The state name.
+ * \returns The state.
  */
 #define PICOTM_GLOBAL_STATE_GET(_name)      \
-    __PICOTM_GLOBAL_STATE_GET(_name)()
+    (&(__PICOTM_GLOBAL_STATE_GET(_name)()->_name))
 
 /**
  * \ingroup group_lib
  * Acquires a reference to an instance of a global state.
  * \param       _name   The state name.
  * \param[out]  _error  Returns an error to the caller.
+ * \returns The acquired state on success, or NULL on error.
  */
 #define PICOTM_GLOBAL_STATE_REF(_name, _error)  \
     __PICOTM_GLOBAL_STATE_REF(_name)(_error)

--- a/include/picotm/picotm-lib-global-state.h
+++ b/include/picotm/picotm-lib-global-state.h
@@ -1,0 +1,186 @@
+/*
+ * MIT License
+ * Copyright (c) 2018   Thomas Zimmermann <tdz@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include "compiler.h"
+#include "picotm-lib-shared-state.h"
+
+/**
+ * \ingroup group_lib
+ * \file
+ * \brief Contains global-state helper macros.
+ *
+ * Picotm provides helper macros for maintaining shared state. Oftentimes
+ * a single shared state is used throughout a module. For this case, picotm
+ * provides additional helper macros that maintain such global state. The
+ * example below declares shared state of type `struct shared`.
+ *
+ * ~~~{.c}
+ *  struct shared {
+ *      int data1;
+ *      int data2;
+ *  };
+ *
+ *  void
+ *  init_shared_fields(struct shared* shared, struct picotm_error* error)
+ *  {
+ *      shared->data1 = 0;
+ *      shared->data2 = 0;
+ *  }
+ *
+ *  void
+ *  uninit_shared_fields(struct shared* shared)
+ *  {
+ *      // nothing to do
+ *  }
+ *
+ *  PICOTM_SHARED_STATE(shared, struct shared)
+ *  PICOTM_SHARED_STATE_STATIC_IMPL(shared,
+ *                                  init_shared_fields,
+ *                                  uninit_shared_fields)
+ * ~~~
+ *
+ * A single global state variable for an existing shared state is declared
+ * with `PICOTM_GLOBAL_STATE_STATIC_IMPL()`. This macro receives the name
+ * of the shared state and expands to an implementation.
+ *
+ * ~~~{.c}
+ *  PICOTM_GLOBAL_STATE(shared)
+ * ~~~
+ *
+ * Users acquire a reference to the global state with
+ * `PICOTM_GLOBAL_STATE_REF()` and release a previously acquired reference
+ * with a call to `PICOTM_GLOBAL_STATE_UNREF()`.
+ *
+ * ~~~{.c}
+ *  struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+ *
+ *  PICOTM_SHARED_STATE_TYPE(shared)* state =
+ *      PICOTM_GLOBAL_STATE_REF(shared, &error);
+ *  if (picotm_error_is_set(&error)) {
+ *      // perform error handling
+ *  }
+ *
+ *  // ...
+ *
+ *  // do something with 'state'
+ *
+ *  // ...
+ *
+ *  // In thread-local cleanup code
+ *  PICOTM_GLOBAL_STATE_UNREF(shared);
+ * ~~~
+ *
+ * Global state is implemented on top of shared state, so the same rules
+ * for thread-safety apply. All references and releases are serialized with
+ * each other and the initializer and clean-up functions. Concurrent access
+ * to shared data files requires additional concurrency control.
+ */
+
+PICOTM_BEGIN_DECLS
+
+struct picotm_error;
+
+/**
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_GLOBAL_STATE_GET(_name)    \
+    _name ## _global_state_get
+
+/**
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_GLOBAL_STATE_REF(_name)    \
+    _name ## _global_state_ref
+
+/**
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_GLOBAL_STATE_UNREF(_name)  \
+    _name ## _global_state_unref
+
+/**
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_GLOBAL_STATE_IMPL(_static, _name)                  \
+    _static PICOTM_SHARED_STATE_TYPE(_name)*                        \
+    __PICOTM_GLOBAL_STATE_GET(_name)(void)                          \
+    {                                                               \
+        static PICOTM_SHARED_STATE_TYPE(_name) s_global =           \
+            PICOTM_SHARED_STATE_INITIALIZER;                        \
+        return &s_global;                                           \
+    }                                                               \
+    _static PICOTM_SHARED_STATE_TYPE(_name)*                        \
+    __PICOTM_GLOBAL_STATE_REF(_name)(struct picotm_error* error)    \
+    {                                                               \
+        PICOTM_SHARED_STATE_TYPE(_name)* global =                   \
+            __PICOTM_GLOBAL_STATE_GET(_name)();                     \
+        return PICOTM_SHARED_STATE_REF(_name, global, error);       \
+    }                                                               \
+    _static void                                                    \
+    __PICOTM_GLOBAL_STATE_UNREF(_name)(void)                        \
+    {                                                               \
+        PICOTM_SHARED_STATE_TYPE(_name)* global =                   \
+            __PICOTM_GLOBAL_STATE_GET(_name)();                     \
+        PICOTM_SHARED_STATE_UNREF(_name, global);                   \
+    }
+
+/**
+ * \ingroup group_lib
+ * Expands to the implementation of a global state.
+ * \param   _name   The state name.
+ */
+#define PICOTM_GLOBAL_STATE_STATIC_IMPL(_name)  \
+    __PICOTM_GLOBAL_STATE_IMPL(static, _name)
+
+/**
+ * \ingroup group_lib
+ * Returns the statically allocated global state. Callers *must* already
+ * hold a reference.
+ * \param   _name   The state name.
+ */
+#define PICOTM_GLOBAL_STATE_GET(_name)      \
+    __PICOTM_GLOBAL_STATE_GET(_name)()
+
+/**
+ * \ingroup group_lib
+ * Acquires a reference to an instance of a global state.
+ * \param       _name   The state name.
+ * \param[out]  _error  Returns an error to the caller.
+ */
+#define PICOTM_GLOBAL_STATE_REF(_name, _error)  \
+    __PICOTM_GLOBAL_STATE_REF(_name)(_error)
+
+/**
+ * \ingroup group_lib
+ * Releases a reference to an instance of a global state.
+ * \param   _name   The state name.
+ */
+#define PICOTM_GLOBAL_STATE_UNREF(_name)    \
+    __PICOTM_GLOBAL_STATE_UNREF(_name)()
+
+PICOTM_END_DECLS

--- a/include/picotm/picotm-lib-shared-state.h
+++ b/include/picotm/picotm-lib-shared-state.h
@@ -1,0 +1,264 @@
+/*
+ * MIT License
+ * Copyright (c) 2018   Thomas Zimmermann <tdz@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include "compiler.h"
+#include "picotm-lib-ptr.h"
+#include "picotm-lib-shared-ref-obj.h"
+
+/**
+ * \ingroup group_lib
+ * \file
+ * \brief Contains shared-state helper macros.
+ *
+ * Picotm provides a number of helper macros to automate management of
+ * shared state. The state is stored in an additional structure, of which
+ * threads can acquire and release references.
+ *
+ * The macro `PICOTM_SHARED_STATE()` declares shared state. It receives
+ * the name and the type of the shared state and expands to a type
+ * definition. For this type, the macro `PICOTM_SHARED_STATE_STATIC_IMPL()`
+ * generates an implementation. For the first and final reference to the
+ * shared state, the generated code invokes an initializer or clean-up
+ * function. both are given as arguments to
+ * `PICOTM_SHARED_STATE_STATIC_IMPL()`. The example below illustrates this
+ * for a state of type `struct shared`.
+ *
+ * ~~~{.c}
+ *  struct shared {
+ *      int data1;
+ *      int data2;
+ *  };
+ *
+ *  void
+ *  init_shared_fields(struct shared* shared, struct picotm_error* error)
+ *  {
+ *      shared->data1 = 0;
+ *      shared->data2 = 0;
+ *  }
+ *
+ *  void
+ *  uninit_shared_fields(struct shared* shared)
+ *  {
+ *      // nothing to do
+ *  }
+ *
+ *  PICOTM_SHARED_STATE(shared, struct shared)
+ *  PICOTM_SHARED_STATE_STATIC_IMPL(shared,
+ *                                  init_shared_fields,
+ *                                  uninit_shared_fields)
+ * ~~~
+ *
+ * A shared-state variable is declared with `PICOTM_SHARED_STATE_TYPE()`. It
+ * has to be initalized by assigning `PICOTM_SHARED_STATE_INITIALIZER`.
+ *
+ * ~~~{.c}
+ *  static PICOTM_SHARED_STATE_TYPE(shared) shared_var =
+ *      PICOTM_SHARED_STATE_INITIALIZER;
+ * ~~~
+ *
+ * A call to `PICOTM_SHARED_STATE_REF()` acquires a reference, a call to
+ * `PICOTM_SHARED_STATE_UNREF()` releases a previously acquired reference.
+ *
+ * ~~~{.c}
+ *  struct picotm_error error = PICOTM_ERROR_INITIALIZER;
+ *
+ *  PICOTM_SHARED_STATE_REF(shared, &shared_var, &error);
+ *  if (picotm_error_is_set(&error)) {
+ *      // perform error handling
+ *  }
+ *
+ *  // ...
+ *
+ *  // do something with shared_var
+ *
+ *  // ...
+ *
+ *  // In thread-local cleanup code
+ *  PICOTM_SHARED_STATE_UNREF(shared, &shared_var);
+ * ~~~
+ *
+ * Acquiring and releasing a reference to a shared state is thread-safe.
+ * Both calls are serialized with each other and the provided initializer
+ * and clean-up functions. Accessing the shared-state data fields requires
+ * additional concurrency control.
+ */
+
+PICOTM_BEGIN_DECLS
+
+struct picotm_error;
+
+/**
+ * \ingroup group_lib
+ * \internal
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_SHARED_STATE_NAME(_name)   \
+    __ ## _name ## _shared_state
+
+/**
+ * \ingroup group_lib
+ * \internal
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_SHARED_STATE_FIRST_REF_CB(_name)   \
+    first_ref_ ## _name ## _shared_state_cb
+
+/**
+ * \ingroup group_lib
+ * \internal
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_SHARED_STATE_FINAL_REF_CB(_name)   \
+    final_ref_ ## _name ## _shared_state_cb
+
+/**
+ * \ingroup group_lib
+ * \internal
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_SHARED_STATE_REF(_name)    \
+    _name ## _shared_state_ref
+
+/**
+ * \ingroup group_lib
+ * \internal
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_SHARED_STATE_UNREF(_name)  \
+    _name ## _shared_state_unref
+
+/**
+ * \ingroup group_lib
+ * Expands to the name of the shared-state structure.
+ * \param   _name   The state name.
+ */
+#define PICOTM_SHARED_STATE_TYPE(_name)         \
+    struct __PICOTM_SHARED_STATE_NAME(_name)
+
+/**
+ * \ingroup group_lib
+ * Defines a shared-state structure.
+ * \param   _name   The state name.
+ * \param   _type   The state type.
+ */
+#define PICOTM_SHARED_STATE(_name, _type)       \
+    PICOTM_SHARED_STATE_TYPE(_name) {           \
+        struct picotm_shared_ref16_obj ref_obj; \
+        _type _name;                            \
+    };
+
+/**
+ * \ingroup group_lib
+ * Initializes a shared-state structure.
+ */
+#define PICOTM_SHARED_STATE_INITIALIZER             \
+{                                                   \
+    .ref_obj = PICOTM_SHARED_REF16_OBJ_INITIALIZER  \
+}
+
+/**
+ * \ingroup group_lib
+ * \internal
+ * \warning This is an internal interface. Don't use it in application code.
+ */
+#define __PICOTM_SHARED_STATE_IMPL(_static, _name, _init, _uninit)      \
+    _static void                                                        \
+    __PICOTM_SHARED_STATE_FIRST_REF_CB(_name)(                          \
+        struct picotm_shared_ref16_obj* ref_obj, void* data,            \
+        struct picotm_error* error)                                     \
+    {                                                                   \
+        PICOTM_SHARED_STATE_TYPE(_name)* shared =                       \
+            picotm_containerof(ref_obj,                                 \
+                               PICOTM_SHARED_STATE_TYPE(_name),         \
+                               ref_obj);                                \
+        (_init)(&(shared->_name), error);                               \
+    }                                                                   \
+    _static PICOTM_SHARED_STATE_TYPE(_name)*                            \
+    __PICOTM_SHARED_STATE_REF(_name)(                                   \
+        PICOTM_SHARED_STATE_TYPE(_name)* self,                          \
+        struct picotm_error* error)                                     \
+    {                                                                   \
+        picotm_shared_ref16_obj_up(                                     \
+            &self->ref_obj, NULL, NULL,                                 \
+            __PICOTM_SHARED_STATE_FIRST_REF_CB(_name),                  \
+            error);                                                     \
+        if (picotm_error_is_set(error)) {                               \
+            return NULL;                                                \
+        }                                                               \
+        return self;                                                    \
+    }                                                                   \
+    _static void                                                        \
+    __PICOTM_SHARED_STATE_FINAL_REF_CB(_name)(                          \
+        struct picotm_shared_ref16_obj* ref_obj, void* data,            \
+        struct picotm_error* error)                                     \
+    {                                                                   \
+        PICOTM_SHARED_STATE_TYPE(_name)* shared =                       \
+            picotm_containerof(ref_obj,                                 \
+                               PICOTM_SHARED_STATE_TYPE(_name),         \
+                               ref_obj);                                \
+        (_uninit)(&(shared->_name));                                    \
+    }                                                                   \
+    _static void                                                        \
+    __PICOTM_SHARED_STATE_UNREF(_name)(                                 \
+        PICOTM_SHARED_STATE_TYPE(_name)* self)                          \
+    {                                                                   \
+        picotm_shared_ref16_obj_down(                                   \
+            &self->ref_obj, NULL, NULL,                                 \
+            __PICOTM_SHARED_STATE_FINAL_REF_CB(_name));                 \
+    }
+
+/**
+ * \ingroup group_lib
+ * Expands to the implementation of a shared state.
+ * \param   _name   The state name.
+ * \param   _init   The state's initializer function.
+ * \param   _uninit The state's clean-up function.
+ */
+#define PICOTM_SHARED_STATE_STATIC_IMPL(_name, _init, _uninit)  \
+    __PICOTM_SHARED_STATE_IMPL(static, _name, _init, _uninit)
+
+/**
+ * \ingroup group_lib
+ * Acquires a reference to an instance of a shared state.
+ * \param       _name   The state name.
+ * \param       _self   The state's instance.
+ * \param[out]  _error  Returns an error to the caller.
+ */
+#define PICOTM_SHARED_STATE_REF(_name, _self, _error)   \
+    __PICOTM_SHARED_STATE_REF(_name)(_self, _error)
+
+/**
+ * \ingroup group_lib
+ * Releases a reference to an instance of a shared state.
+ * \param   _name   The state name.
+ * \param   _self   The state's instance.
+ */
+#define PICOTM_SHARED_STATE_UNREF(_name, _self) \
+    __PICOTM_SHARED_STATE_UNREF(_name)(_self)
+
+PICOTM_END_DECLS

--- a/modules/libc/src/cwd/module.c
+++ b/modules/libc/src/cwd/module.c
@@ -49,7 +49,7 @@ uninit_cwd_shared_state_fields(struct cwd* cwd)
 }
 
 PICOTM_SHARED_STATE(cwd, struct cwd);
-PICOTM_SHARED_STATE_STATIC_IMPL(cwd,
+PICOTM_SHARED_STATE_STATIC_IMPL(cwd, struct cwd,
                                 init_cwd_shared_state_fields,
                                 uninit_cwd_shared_state_fields)
 
@@ -57,7 +57,7 @@ PICOTM_SHARED_STATE_STATIC_IMPL(cwd,
  * Global state
  */
 
-PICOTM_GLOBAL_STATE_STATIC_IMPL(cwd)
+PICOTM_GLOBAL_STATE_STATIC_IMPL(cwd, struct cwd)
 
 /*
  * Module interface
@@ -158,8 +158,7 @@ get_cwd_tx(bool initialize, struct picotm_error* error)
         return NULL;
     }
 
-    PICOTM_SHARED_STATE_TYPE(cwd)* global =
-        PICOTM_GLOBAL_STATE_REF(cwd, error);
+    struct cwd* cwd = PICOTM_GLOBAL_STATE_REF(cwd, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
@@ -170,7 +169,7 @@ get_cwd_tx(bool initialize, struct picotm_error* error)
     }
 
     cwd_log_init(&t_module.log, module);
-    cwd_tx_init(&t_module.tx, &t_module.log, &global->cwd);
+    cwd_tx_init(&t_module.tx, &t_module.log, cwd);
 
     t_module.is_initialized = true;
 

--- a/modules/libc/src/fildes/module.c
+++ b/modules/libc/src/fildes/module.c
@@ -53,7 +53,7 @@ uninit_fildes_shared_state_fields(struct fildes* fildes)
 }
 
 PICOTM_SHARED_STATE(fildes, struct fildes);
-PICOTM_SHARED_STATE_STATIC_IMPL(fildes,
+PICOTM_SHARED_STATE_STATIC_IMPL(fildes, struct fildes,
                                 init_fildes_shared_state_fields,
                                 uninit_fildes_shared_state_fields)
 
@@ -61,7 +61,7 @@ PICOTM_SHARED_STATE_STATIC_IMPL(fildes,
  * Global state
  */
 
-PICOTM_GLOBAL_STATE_STATIC_IMPL(fildes)
+PICOTM_GLOBAL_STATE_STATIC_IMPL(fildes, struct fildes)
 
 /*
  * Module interface
@@ -149,8 +149,7 @@ get_fildes_tx(bool initialize, struct picotm_error* error)
         return NULL;
     }
 
-    PICOTM_SHARED_STATE_TYPE(fildes)* global =
-        PICOTM_GLOBAL_STATE_REF(fildes, error);
+    struct fildes* fildes = PICOTM_GLOBAL_STATE_REF(fildes, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
@@ -161,7 +160,7 @@ get_fildes_tx(bool initialize, struct picotm_error* error)
     }
 
     fildes_log_init(&t_module.log, module);
-    fildes_tx_init(&t_module.tx, &global->fildes, &t_module.log);
+    fildes_tx_init(&t_module.tx, fildes, &t_module.log);
 
     t_module.is_initialized = true;
 

--- a/modules/tm/src/module.c
+++ b/modules/tm/src/module.c
@@ -49,7 +49,7 @@ uninit_vmem_shared_state_fields(struct tm_vmem* vmem)
 }
 
 PICOTM_SHARED_STATE(vmem, struct tm_vmem);
-PICOTM_SHARED_STATE_STATIC_IMPL(vmem,
+PICOTM_SHARED_STATE_STATIC_IMPL(vmem, struct tm_vmem,
                                 init_vmem_shared_state_fields,
                                 uninit_vmem_shared_state_fields)
 
@@ -57,7 +57,7 @@ PICOTM_SHARED_STATE_STATIC_IMPL(vmem,
  * Global state
  */
 
-PICOTM_GLOBAL_STATE_STATIC_IMPL(vmem)
+PICOTM_GLOBAL_STATE_STATIC_IMPL(vmem, struct tm_vmem)
 
 /*
  * Module interface
@@ -142,8 +142,7 @@ get_vmem_tx(bool initialize, struct picotm_error* error)
         return NULL;
     }
 
-    PICOTM_SHARED_STATE_TYPE(vmem)* global =
-        PICOTM_GLOBAL_STATE_REF(vmem, error);
+    struct tm_vmem* vmem = PICOTM_GLOBAL_STATE_REF(vmem, error);
     if (picotm_error_is_set(error)) {
         return NULL;
     }
@@ -153,7 +152,7 @@ get_vmem_tx(bool initialize, struct picotm_error* error)
         goto err_picotm_register_module;
     }
 
-    tm_vmem_tx_init(&t_module.tx, &global->vmem, module);
+    tm_vmem_tx_init(&t_module.tx, vmem, module);
 
     t_module.is_initialized = true;
 

--- a/src/picotm.c
+++ b/src/picotm.c
@@ -61,7 +61,7 @@ uninit_picotm_shared_state_fields(struct picotm* picotm)
 }
 
 PICOTM_SHARED_STATE(picotm, struct picotm);
-PICOTM_SHARED_STATE_STATIC_IMPL(picotm,
+PICOTM_SHARED_STATE_STATIC_IMPL(picotm, struct picotm,
                                 init_picotm_shared_state_fields,
                                 uninit_picotm_shared_state_fields)
 
@@ -69,7 +69,7 @@ PICOTM_SHARED_STATE_STATIC_IMPL(picotm,
  * Global data
  */
 
-PICOTM_GLOBAL_STATE_STATIC_IMPL(picotm)
+PICOTM_GLOBAL_STATE_STATIC_IMPL(picotm, struct picotm)
 
 /*
  * Thread-local data
@@ -109,13 +109,12 @@ init_thread_state_fields(struct thread_state* thread,
     assert(thread);
     assert(!thread->fields_are_initialized);
 
-    PICOTM_SHARED_STATE_TYPE(picotm)* global =
-        PICOTM_GLOBAL_STATE_REF(picotm, error);
+    struct picotm* global = PICOTM_GLOBAL_STATE_REF(picotm, error);
     if (picotm_error_is_set(error)) {
         return;
     }
 
-    picotm_tx_init(&thread->tx, &global->picotm.lm, error);
+    picotm_tx_init(&thread->tx, &global->lm, error);
     if (picotm_error_is_set(error)) {
         goto err_picotm_tx_init;
     }


### PR DESCRIPTION
More complex modules contain shared or global state (i.e., state that is used by multiple threads at the same time). This patch set cleans up the shared-state handling and adds helper macros that generate most of the involved boilerplate code.