### PR TITLE
Clean up modules and interface's release call-back function

### DIFF
--- a/include/picotm/picotm-module.h
+++ b/include/picotm/picotm-module.h
@@ -130,7 +130,7 @@ typedef void (*picotm_module_finish_function)(void* data,
  * Invoked by picotm to clean up a module's resources when the thread exists.
  * \param   data    The pointer to module-specific data.
  */
-typedef void (*picotm_module_uninit_function)(void* data);
+typedef void (*picotm_module_release_function)(void* data);
 
 /**
  * The module structure contains call-back functions for each
@@ -144,7 +144,7 @@ struct picotm_module_ops {
     picotm_module_apply_event_function apply_event;
     picotm_module_undo_event_function undo_event;
     picotm_module_finish_function finish;
-    picotm_module_uninit_function uninit;
+    picotm_module_release_function release;
 };
 
 PICOTM_NOTHROW

--- a/modules/libc/src/allocator/module.c
+++ b/modules/libc/src/allocator/module.c
@@ -79,10 +79,8 @@ finish_cb(void* data, struct picotm_error* error)
 }
 
 static void
-uninit_cb(void* data)
+release_cb(void* data)
 {
-    struct allocator_module* module = data;
-
     PICOTM_THREAD_STATE_RELEASE(allocator_module);
 }
 
@@ -94,7 +92,7 @@ init_allocator_module(struct allocator_module* module,
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,
         .finish = finish_cb,
-        .uninit = uninit_cb
+        .release = release_cb
     };
 
     unsigned long module_id = picotm_register_module(&s_ops, module, error);

--- a/modules/libc/src/cwd/module.c
+++ b/modules/libc/src/cwd/module.c
@@ -135,7 +135,7 @@ finish_cb(void* data, struct picotm_error* error)
 }
 
 static void
-uninit_cb(void* data)
+release_cb(void* data)
 {
     PICOTM_THREAD_STATE_RELEASE(cwd_module);
 }
@@ -147,7 +147,7 @@ init_cwd_module(struct module* module, struct picotm_error* error)
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,
         .finish = finish_cb,
-        .uninit = uninit_cb
+        .release = release_cb
     };
 
     struct cwd* cwd = PICOTM_GLOBAL_STATE_REF(cwd, error);

--- a/modules/libc/src/error/module.c
+++ b/modules/libc/src/error/module.c
@@ -78,7 +78,7 @@ finish_cb(void* data, struct picotm_error* error)
 }
 
 static void
-uninit_cb(void* data)
+release_cb(void* data)
 {
     PICOTM_THREAD_STATE_RELEASE(error_module);
 }
@@ -89,7 +89,7 @@ init_error_module(struct error_module* module, struct picotm_error* error)
     static const struct picotm_module_ops s_ops = {
         .undo = undo_cb,
         .finish = finish_cb,
-        .uninit = uninit_cb
+        .release = release_cb
     };
 
     unsigned long module_id = picotm_register_module(&s_ops, module, error);

--- a/modules/libc/src/fildes/module.c
+++ b/modules/libc/src/fildes/module.c
@@ -124,7 +124,7 @@ finish_cb(void* data, struct picotm_error* error)
 }
 
 static void
-uninit_cb(void* data)
+release_cb(void* data)
 {
     PICOTM_THREAD_STATE_RELEASE(fildes_module);
 }
@@ -137,7 +137,7 @@ init_fildes_module(struct fildes_module* module, struct picotm_error* error)
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,
         .finish = finish_cb,
-        .uninit = uninit_cb
+        .release = release_cb
     };
 
     struct fildes* fildes = PICOTM_GLOBAL_STATE_REF(fildes, error);

--- a/modules/libc/src/signal/module.c
+++ b/modules/libc/src/signal/module.c
@@ -77,7 +77,7 @@ finish_cb(void* data, struct picotm_error* error)
 }
 
 static void
-uninit_cb(void* data)
+release_cb(void* data)
 {
     PICOTM_THREAD_STATE_RELEASE(signal_module);
 }
@@ -88,7 +88,7 @@ init_signal_module(struct module* module, struct picotm_error* error)
     static const struct picotm_module_ops s_ops = {
         .begin = begin_cb,
         .finish = finish_cb,
-        .uninit = uninit_cb
+        .release = release_cb
     };
 
     unsigned long module_id = picotm_register_module(&s_ops, module, error);

--- a/modules/libm/src/module.c
+++ b/modules/libm/src/module.c
@@ -78,7 +78,7 @@ finish_cb(void* data, struct picotm_error* error)
 }
 
 static void
-uninit_cb(void* data)
+release_cb(void* data)
 {
     PICOTM_THREAD_STATE_RELEASE(fpu_module);
 }
@@ -89,7 +89,7 @@ init_fpu_module(struct fpu_module* module, struct picotm_error* error)
     static const struct picotm_module_ops s_ops = {
         .undo = undo_cb,
         .finish = finish_cb,
-        .uninit = uninit_cb
+        .release = release_cb
     };
 
     unsigned long module_id = picotm_register_module(&s_ops, module, error);

--- a/modules/libm/src/module.c
+++ b/modules/libm/src/module.c
@@ -40,21 +40,36 @@ struct fpu_module {
 };
 
 static void
-fpu_module_undo(struct fpu_module* module, struct picotm_error* error)
+fpu_module_init(struct fpu_module* self, unsigned long module_id,
+                struct picotm_error* error)
 {
-    fpu_tx_undo(&module->tx, error);
+    assert(self);
+
+    fpu_tx_init(&self->tx, module_id, error);
 }
 
 static void
-fpu_module_finish(struct fpu_module* module, struct picotm_error* error)
+fpu_module_uninit(struct fpu_module* self)
 {
-    fpu_tx_finish(&module->tx);
+    assert(self);
+
+    fpu_tx_uninit(&self->tx);
 }
 
 static void
-fpu_module_uninit(struct fpu_module* module)
+fpu_module_undo(struct fpu_module* self, struct picotm_error* error)
 {
-    fpu_tx_uninit(&module->tx);
+    assert(self);
+
+    fpu_tx_undo(&self->tx, error);
+}
+
+static void
+fpu_module_finish(struct fpu_module* self, struct picotm_error* error)
+{
+    assert(self);
+
+    fpu_tx_finish(&self->tx);
 }
 
 /*
@@ -68,13 +83,15 @@ PICOTM_THREAD_STATE_STATIC_DECL(fpu_module)
 static void
 undo_cb(void* data, struct picotm_error* error)
 {
-    fpu_module_undo(data, error);
+    struct fpu_module* module = data;
+    fpu_module_undo(module, error);
 }
 
 static void
 finish_cb(void* data, struct picotm_error* error)
 {
-    fpu_module_finish(data, error);
+    struct fpu_module* module = data;
+    fpu_module_finish(module, error);
 }
 
 static void
@@ -97,7 +114,7 @@ init_fpu_module(struct fpu_module* module, struct picotm_error* error)
         return;
     }
 
-    fpu_tx_init(&module->tx, module_id, error);
+    fpu_module_init(module, module_id, error);
     if (picotm_error_is_set(error)) {
         return;
     }

--- a/modules/tm/src/module.c
+++ b/modules/tm/src/module.c
@@ -79,7 +79,7 @@ tm_module_init(struct tm_module* self, struct tm_vmem* vmem,
 static void
 tm_module_uninit(struct tm_module* self)
 {
-    tm_vmem_tx_release(&self->tx);
+    tm_vmem_tx_uninit(&self->tx);
 }
 
 static void

--- a/modules/tm/src/module.c
+++ b/modules/tm/src/module.c
@@ -120,7 +120,7 @@ finish_cb(void* data, struct picotm_error* error)
 }
 
 static void
-uninit_cb(void* data)
+release_cb(void* data)
 {
     PICOTM_THREAD_STATE_RELEASE(tm_module);
 }
@@ -132,7 +132,7 @@ init_tm_module(struct tm_module* module, struct picotm_error* error)
         .apply = apply_cb,
         .undo = undo_cb,
         .finish = finish_cb,
-        .uninit = uninit_cb
+        .release = release_cb
     };
 
     struct tm_vmem* vmem = PICOTM_GLOBAL_STATE_REF(vmem, error);

--- a/modules/tm/src/vmem_tx.c
+++ b/modules/tm/src/vmem_tx.c
@@ -51,7 +51,7 @@ cleanup_page(struct picotm_slist* item)
 }
 
 void
-tm_vmem_tx_release(struct tm_vmem_tx* vmem_tx)
+tm_vmem_tx_uninit(struct tm_vmem_tx* vmem_tx)
 {
     picotm_slist_cleanup_0(&vmem_tx->active_pages, cleanup_page);
     picotm_slist_uninit_head(&vmem_tx->active_pages);

--- a/modules/tm/src/vmem_tx.h
+++ b/modules/tm/src/vmem_tx.h
@@ -65,11 +65,10 @@ tm_vmem_tx_init(struct tm_vmem_tx* vmem_tx, struct tm_vmem* vmem,
                 unsigned long module);
 
 /**
- * Releases all memory and resources allocated by the transaction. The
- * transaction's data structure will remain initialized and useable after
- * this call returned.
+ * Releases all memory and resources allocated by the transaction.
  */
-void tm_vmem_tx_release(struct tm_vmem_tx* vmem_tx);
+void
+tm_vmem_tx_uninit(struct tm_vmem_tx* vmem_tx);
 
 /**
  * Executes a load operation.
@@ -119,7 +118,8 @@ void
 tm_vmem_tx_undo(struct tm_vmem_tx* vmem_tx, struct picotm_error* error);
 
 /**
- * Cleans up a transcation's resources.
+ * Cleans up a transcation's resources. The transaction's data structure
+ * will remain initialized and useable after this call returned.
  */
 void
 tm_vmem_tx_finish(struct tm_vmem_tx* vmem_tx, struct picotm_error* error);

--- a/modules/txlib/src/txlib_module.c
+++ b/modules/txlib/src/txlib_module.c
@@ -112,7 +112,7 @@ finish_cb(void* data, struct picotm_error* error)
 }
 
 static void
-uninit_cb(void* data)
+release_cb(void* data)
 {
     PICOTM_THREAD_STATE_RELEASE(txlib_module);
 }
@@ -125,7 +125,7 @@ init_txlib_module(struct txlib_module* module, struct picotm_error* error)
         .apply_event = apply_event_cb,
         .undo_event = undo_event_cb,
         .finish = finish_cb,
-        .uninit = uninit_cb
+        .release = release_cb
     };
 
     unsigned long module_id = picotm_register_module(&s_ops, module, error);

--- a/src/picotm_module.c
+++ b/src/picotm_module.c
@@ -39,13 +39,13 @@ picotm_module_init(struct picotm_module* self,
 }
 
 void
-picotm_module_uninit(struct picotm_module* self)
+picotm_module_release(struct picotm_module* self)
 {
     assert(self);
     assert(self->ops);
 
-    if (self->ops->uninit) {
-        self->ops->uninit(self->data);
+    if (self->ops->release) {
+        self->ops->release(self->data);
     }
 }
 

--- a/src/picotm_module.h
+++ b/src/picotm_module.h
@@ -50,7 +50,7 @@ picotm_module_init(struct picotm_module* self,
                    void* data);
 
 void
-picotm_module_uninit(struct picotm_module* self);
+picotm_module_release(struct picotm_module* self);
 
 void *
 picotm_module_get_data(const struct picotm_module* self);

--- a/src/picotm_tx.c
+++ b/src/picotm_tx.c
@@ -87,7 +87,7 @@ picotm_tx_release(struct picotm_tx* self)
     const struct picotm_module* module_end = self->module + self->nmodules;
 
     while (module < module_end) {
-        picotm_module_uninit(module);
+        picotm_module_release(module);
         ++module;
     }
 }


### PR DESCRIPTION
The modules' implementations are not well separated from the call-back functions. The release call-back function is currently called uninit. This patch set cleans this up.