### PR TITLE
Fix look-up for treemaps

### DIFF
--- a/src/picotm-lib-shared-treemap.c
+++ b/src/picotm-lib-shared-treemap.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -272,6 +272,9 @@ lookup_value_entry(atomic_uintptr_t* entry_ptr, unsigned long depth,
             entry_ptr, create_dirs, level_nentries(level_nbits), error);
         if (picotm_error_is_set(error)) {
             return NULL;
+        } else if (!dir) {
+            assert(!create_dirs);
+            return NULL;
         }
 
         entry_ptr = dir->entry + entry_index(key, depth, level_nbits);
@@ -335,6 +338,8 @@ picotm_shared_treemap_find_value(
                                                      self->level_nbits,
                                                      error);
     if (picotm_error_is_set(error)) {
+        return 0;
+    } if (!entry_ptr) {
         return 0;
     }
 

--- a/src/picotm-lib-treemap.c
+++ b/src/picotm-lib-treemap.c
@@ -280,6 +280,10 @@ retrieve_value(
         return entry;
     }
 
+    if (!value_create) {
+        return 0; /* don't create new value */
+    }
+
     entry = value_create(key, treemap, error);
     if (picotm_error_is_set(error)) {
         return 0;

--- a/src/picotm-lib-treemap.c
+++ b/src/picotm-lib-treemap.c
@@ -1,6 +1,6 @@
 /*
  * MIT License
- * Copyright (c) 2017   Thomas Zimmermann <tdz@users.sourceforge.net>
+ * Copyright (c) 2017-2018  Thomas Zimmermann <tdz@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -257,6 +257,9 @@ lookup_value_entry(uintptr_t* entry_ptr, unsigned long depth,
                                                error);
         if (picotm_error_is_set(error)) {
             return NULL;
+        } else if (!dir) {
+            assert(!create_dirs);
+            return NULL;
         }
 
         entry_ptr = dir->entry + entry_index(key, depth, level_nbits);
@@ -311,6 +314,8 @@ picotm_treemap_find_value(struct picotm_treemap* self,
                                               key, !!(value_create),
                                               self->level_nbits, error);
     if (picotm_error_is_set(error)) {
+        return 0;
+    } else if (!entry_ptr) {
         return 0;
     }
 


### PR DESCRIPTION
Looking up a non-existent value from a (shared) treemap can result in undefined behavior. The treemap's looku-up function does not generate a directory or value in this case; while other functions of the implementation expect this.