### PR TITLE
libc: Refer to 'locale/locale_event.h' in Makefile.am

### DIFF
--- a/modules/libc/src/Makefile.am
+++ b/modules/libc/src/Makefile.am
@@ -163,7 +163,7 @@ libpicotm_c_la_SOURCES = allocator/allocator_event.c \
                          locale/locale.c \
                          locale/locale.h \
                          locale/locale_event.c \
-                         locole/locale_event.h \
+                         locale/locale_event.h \
                          locale/locale_log.c \
                          locale/locale_log.h \
                          locale/locale_tx.c \


### PR DESCRIPTION
The Makefile.am file contained a typo.

Signed-off-by: Thomas Zimmermann <contact@tzimmermann.org>