### PR TITLE
libc/files: Fix [static 1] usage

### DIFF
--- a/modules/libc/src/fildes/chrdevtab.c
+++ b/modules/libc/src/fildes/chrdevtab.c
@@ -54,8 +54,8 @@ fildes_chrdevtab_uninit(struct fildes_chrdevtab self[static 1])
 }
 
 struct chrdev*
-fildes_chrdevtab_ref_fildes(struct fildes_chrdevtab* self, int fildes,
-                            bool new_file, struct picotm_error* error)
+fildes_chrdevtab_ref_fildes(struct fildes_chrdevtab self[static 1], int fildes,
+                            bool new_file, struct picotm_error error[static 1])
 {
     struct file* file = fildes_filetab_ref_fildes(&self->filetab, fildes,
                                                   new_file, error);
@@ -66,7 +66,8 @@ fildes_chrdevtab_ref_fildes(struct fildes_chrdevtab* self, int fildes,
 }
 
 size_t
-fildes_chrdevtab_index(struct fildes_chrdevtab* self, struct chrdev* chrdev)
+fildes_chrdevtab_index(struct fildes_chrdevtab self[static 1],
+                       struct chrdev chrdev[static 1])
 {
     return fildes_filetab_index(&self->filetab, &chrdev->base);
 }

--- a/modules/libc/src/fildes/pipebuf.c
+++ b/modules/libc/src/fildes/pipebuf.c
@@ -32,7 +32,8 @@ init_rwlock(void* data, struct picotm_error error[static 1])
 }
 
 void
-pipebuf_init(struct pipebuf* self, struct picotm_error* error)
+pipebuf_init(struct pipebuf self[static 1],
+             struct picotm_error error[static 1])
 {
     assert(self);
 
@@ -60,7 +61,7 @@ uninit_rwlock(void* data, struct picotm_error error[static 1])
 }
 
 void
-pipebuf_uninit(struct pipebuf* self)
+pipebuf_uninit(struct pipebuf self[static 1])
 {
     struct picotm_error ignored = PICOTM_ERROR_INITIALIZER;
 
@@ -84,16 +85,16 @@ pipebuf_try_rdlock_field(struct pipebuf self[static 1],
 }
 
 void
-pipebuf_try_wrlock_field(struct pipebuf* self, enum pipebuf_field field,
-                         struct picotm_rwstate* rwstate,
-                         struct picotm_error* error)
+pipebuf_try_wrlock_field(struct pipebuf self[static 1], enum pipebuf_field field,
+                         struct picotm_rwstate rwstate[static 1],
+                         struct picotm_error error[static 1])
 {
     picotm_rwstate_try_wrlock(rwstate, self->rwlock + field, error);
 }
 
 void
-pipebuf_unlock_field(struct pipebuf* self, enum pipebuf_field field,
-                     struct picotm_rwstate* rwstate)
+pipebuf_unlock_field(struct pipebuf self[static 1], enum pipebuf_field field,
+                     struct picotm_rwstate rwstate[static 1])
 {
     picotm_rwstate_unlock(rwstate, self->rwlock + field);
 }

--- a/modules/libc/src/fildes/regfiletab.c
+++ b/modules/libc/src/fildes/regfiletab.c
@@ -40,8 +40,8 @@ static const struct fildes_filetab_ops regfiletab_ops = {
 };
 
 void
-fildes_regfiletab_init(struct fildes_regfiletab* self,
-                       struct picotm_error* error)
+fildes_regfiletab_init(struct fildes_regfiletab self[static 1],
+                       struct picotm_error error[static 1])
 {
     fildes_filetab_init(&self->filetab, &regfiletab_ops, sizeof(self->tab),
                         (void*)&self->tab, sizeof(self->tab[0]), error);

--- a/modules/libc/src/fildes/seekbuf.c
+++ b/modules/libc/src/fildes/seekbuf.c
@@ -108,8 +108,8 @@ seekbuf_try_wrlock_field(struct seekbuf self[static 1], enum seekbuf_field field
 }
 
 void
-seekbuf_unlock_field(struct seekbuf* self, enum seekbuf_field field,
-                     struct picotm_rwstate* rwstate)
+seekbuf_unlock_field(struct seekbuf self[static 1], enum seekbuf_field field,
+                     struct picotm_rwstate rwstate[static 1])
 {
     picotm_rwstate_unlock(rwstate, self->rwlock + field);
 }


### PR DESCRIPTION
Several function definitions use a pointer in places where [static 1] is required. Fix them.