### PR TITLE
Remove Copyright statements from licensing information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
-# Copyright (c) 2020        Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/LICENSES/Makefile.am
+++ b/LICENSES/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,5 @@
 dnl
 dnl picotm - A system-level transaction manager
-dnl Copyright (c) 2017-2020 Thomas Zimmermann
 dnl
 dnl This program is free software: you can redistribute it and/or modify
 dnl it under the terms of the GNU Lesser General Public License as published by

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/extras/aclocal/Makefile.am
+++ b/extras/aclocal/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/extras/aclocal/check_picotm.m4
+++ b/extras/aclocal/check_picotm.m4
@@ -5,8 +5,6 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2017-2018 Thomas Zimmermann
-#
 #   Copying and distribution of this file, with or without modification,
 #   are permitted in any medium without royalty provided the copyright
 #   notice and this notice are preserved.  This file is offered as-is,

--- a/extras/aclocal/check_picotm_c.m4
+++ b/extras/aclocal/check_picotm_c.m4
@@ -5,8 +5,6 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2017-2018 Thomas Zimmermann
-#
 #   Copying and distribution of this file, with or without modification,
 #   are permitted in any medium without royalty provided the copyright
 #   notice and this notice are preserved.  This file is offered as-is,

--- a/extras/aclocal/check_picotm_ptrdata.m4
+++ b/extras/aclocal/check_picotm_ptrdata.m4
@@ -5,8 +5,6 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2018  Thomas Zimmermann
-#
 #   Copying and distribution of this file, with or without modification,
 #   are permitted in any medium without royalty provided the copyright
 #   notice and this notice are preserved.  This file is offered as-is,

--- a/extras/aclocal/check_picotm_tm.m4
+++ b/extras/aclocal/check_picotm_tm.m4
@@ -5,8 +5,6 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2017-2018 Thomas Zimmermann
-#
 #   Copying and distribution of this file, with or without modification,
 #   are permitted in any medium without royalty provided the copyright
 #   notice and this notice are preserved.  This file is offered as-is,

--- a/extras/aclocal/check_picotm_txlib.m4
+++ b/extras/aclocal/check_picotm_txlib.m4
@@ -5,8 +5,6 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2017  Thomas Zimmermann
-#
 #   Copying and distribution of this file, with or without modification,
 #   are permitted in any medium without royalty provided the copyright
 #   notice and this notice are preserved.  This file is offered as-is,

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/compiler.h
+++ b/include/picotm/compiler.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/config/picotm-config.h.in
+++ b/include/picotm/config/picotm-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-error-base.h
+++ b/include/picotm/picotm-error-base.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-error.h
+++ b/include/picotm/picotm-error.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-array.h
+++ b/include/picotm/picotm-lib-array.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-global-state.h
+++ b/include/picotm/picotm-lib-global-state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-ptr.h
+++ b/include/picotm/picotm-lib-ptr.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-ref.h
+++ b/include/picotm/picotm-lib-ref.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-rwlock.h
+++ b/include/picotm/picotm-lib-rwlock.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-rwstate.h
+++ b/include/picotm/picotm-lib-rwstate.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-shared-ref-obj.h
+++ b/include/picotm/picotm-lib-shared-ref-obj.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-shared-state.h
+++ b/include/picotm/picotm-lib-shared-state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-shared-treemap.h
+++ b/include/picotm/picotm-lib-shared-treemap.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-slist.h
+++ b/include/picotm/picotm-lib-slist.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-spinlock.h
+++ b/include/picotm/picotm-lib-spinlock.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-state.h
+++ b/include/picotm/picotm-lib-state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-tab.h
+++ b/include/picotm/picotm-lib-tab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-thread-state.h
+++ b/include/picotm/picotm-lib-thread-state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-lib-treemap.h
+++ b/include/picotm/picotm-lib-treemap.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm-module.h
+++ b/include/picotm/picotm-module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/picotm/picotm.h
+++ b/include/picotm/picotm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/check_module_intf.m4
+++ b/m4-local/check_module_intf.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2017  Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/check_module_type.m4
+++ b/m4-local/check_module_type.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2017  Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/config_arithmetic.m4
+++ b/m4-local/config_arithmetic.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2018  Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/config_cast.m4
+++ b/m4-local/config_cast.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2018  Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/config_libc.m4
+++ b/m4-local/config_libc.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2017-2018 Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/config_libm.m4
+++ b/m4-local/config_libm.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2017-2018 Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/config_libpthread.m4
+++ b/m4-local/config_libpthread.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2017-2018 Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/config_ptrdata.m4
+++ b/m4-local/config_ptrdata.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2018  Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/config_tm.m4
+++ b/m4-local/config_tm.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2017-2018 Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/m4-local/config_txlib.m4
+++ b/m4-local/config_txlib.m4
@@ -6,7 +6,6 @@
 # LICENSE
 #
 #   picotm - A system-level transaction manager
-#   Copyright (c) 2017-2018 Thomas Zimmermann
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Lesser General Public License as published by

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/Makefile.am
+++ b/modules/arithmetic/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/include/Makefile.am
+++ b/modules/arithmetic/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/include/picotm/config/picotm-arithmetic-config.h.in
+++ b/modules/arithmetic/include/picotm/config/picotm-arithmetic-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/include/picotm/picotm-arithmetic-ctypes.h
+++ b/modules/arithmetic/include/picotm/picotm-arithmetic-ctypes.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/include/picotm/picotm-arithmetic.h
+++ b/modules/arithmetic/include/picotm/picotm-arithmetic.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/src/Makefile.am
+++ b/modules/arithmetic/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/src/arithmetic.c
+++ b/modules/arithmetic/src/arithmetic.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/src/arithmetic.h
+++ b/modules/arithmetic/src/arithmetic.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/tests/Makefile.am
+++ b/modules/arithmetic/tests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/tests/pubapi/Makefile.am
+++ b/modules/arithmetic/tests/pubapi/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/arithmetic/tests/pubapi/arithmetic-pubapi-t1-valgrind.test
+++ b/modules/arithmetic/tests/pubapi/arithmetic-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/arithmetic/tests/pubapi/arithmetic-pubapi-t1.test
+++ b/modules/arithmetic/tests/pubapi/arithmetic-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/arithmetic/tests/pubapi/arithmetic-pubapi-t4.test
+++ b/modules/arithmetic/tests/pubapi/arithmetic-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/arithmetic/tests/pubapi/arithmetic_pubapi.c
+++ b/modules/arithmetic/tests/pubapi/arithmetic_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/cast/Makefile.am
+++ b/modules/cast/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/include/Makefile.am
+++ b/modules/cast/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/include/picotm/config/picotm-cast-config.h.in
+++ b/modules/cast/include/picotm/config/picotm-cast-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/include/picotm/picotm-cast-ctypes.h
+++ b/modules/cast/include/picotm/picotm-cast-ctypes.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/include/picotm/picotm-cast.h
+++ b/modules/cast/include/picotm/picotm-cast.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/src/Makefile.am
+++ b/modules/cast/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/src/cast.c
+++ b/modules/cast/src/cast.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/src/cast.h
+++ b/modules/cast/src/cast.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/tests/Makefile.am
+++ b/modules/cast/tests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/tests/pubapi/Makefile.am
+++ b/modules/cast/tests/pubapi/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/cast/tests/pubapi/cast-pubapi-t1-valgrind.test
+++ b/modules/cast/tests/pubapi/cast-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/cast/tests/pubapi/cast-pubapi-t1.test
+++ b/modules/cast/tests/pubapi/cast-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/cast/tests/pubapi/cast-pubapi-t4.test
+++ b/modules/cast/tests/pubapi/cast-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/cast/tests/pubapi/cast_pubapi.c
+++ b/modules/cast/tests/pubapi/cast_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libc/Makefile.am
+++ b/modules/libc/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/Makefile.am
+++ b/modules/libc/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/config/picotm-libc-config.h.in
+++ b/modules/libc/include/picotm/config/picotm-libc-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/errno.h
+++ b/modules/libc/include/picotm/errno.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/fcntl-tm.h
+++ b/modules/libc/include/picotm/fcntl-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/fcntl.h
+++ b/modules/libc/include/picotm/fcntl.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/locale-tm.h
+++ b/modules/libc/include/picotm/locale-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/locale.h
+++ b/modules/libc/include/picotm/locale.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/picotm-libc.h
+++ b/modules/libc/include/picotm/picotm-libc.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/sched.h
+++ b/modules/libc/include/picotm/sched.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/stdbool.h
+++ b/modules/libc/include/picotm/stdbool.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/stddef.h
+++ b/modules/libc/include/picotm/stddef.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/stdint.h
+++ b/modules/libc/include/picotm/stdint.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/stdio-tm.h
+++ b/modules/libc/include/picotm/stdio-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/stdio.h
+++ b/modules/libc/include/picotm/stdio.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/stdlib-tm.h
+++ b/modules/libc/include/picotm/stdlib-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/stdlib.h
+++ b/modules/libc/include/picotm/stdlib.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/string-tm.h
+++ b/modules/libc/include/picotm/string-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/string.h
+++ b/modules/libc/include/picotm/string.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/sys/socket-tm.h
+++ b/modules/libc/include/picotm/sys/socket-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/sys/socket.h
+++ b/modules/libc/include/picotm/sys/socket.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/sys/stat-tm.h
+++ b/modules/libc/include/picotm/sys/stat-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/sys/stat.h
+++ b/modules/libc/include/picotm/sys/stat.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/sys/types.h
+++ b/modules/libc/include/picotm/sys/types.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/time.h
+++ b/modules/libc/include/picotm/time.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/unistd-tm.h
+++ b/modules/libc/include/picotm/unistd-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/include/picotm/unistd.h
+++ b/modules/libc/include/picotm/unistd.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/Makefile.am
+++ b/modules/libc/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2020   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/allocator/allocator_event.c
+++ b/modules/libc/src/allocator/allocator_event.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/allocator/allocator_event.h
+++ b/modules/libc/src/allocator/allocator_event.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/allocator/allocator_log.c
+++ b/modules/libc/src/allocator/allocator_log.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/allocator/allocator_log.h
+++ b/modules/libc/src/allocator/allocator_log.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/allocator/allocator_tx.c
+++ b/modules/libc/src/allocator/allocator_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/allocator/allocator_tx.h
+++ b/modules/libc/src/allocator/allocator_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/allocator/module.c
+++ b/modules/libc/src/allocator/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/allocator/module.h
+++ b/modules/libc/src/allocator/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/compat/get_current_dir_name.c
+++ b/modules/libc/src/compat/get_current_dir_name.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/compat/get_current_dir_name.h
+++ b/modules/libc/src/compat/get_current_dir_name.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/compat/malloc_usable_size.c
+++ b/modules/libc/src/compat/malloc_usable_size.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/compat/malloc_usable_size.h
+++ b/modules/libc/src/compat/malloc_usable_size.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/compat/static_assert.h
+++ b/modules/libc/src/compat/static_assert.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/compat/temp_failure_retry.h
+++ b/modules/libc/src/compat/temp_failure_retry.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/cwd.c
+++ b/modules/libc/src/cwd/cwd.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/cwd.h
+++ b/modules/libc/src/cwd/cwd.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/cwd_event.c
+++ b/modules/libc/src/cwd/cwd_event.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/cwd_event.h
+++ b/modules/libc/src/cwd/cwd_event.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/cwd_log.c
+++ b/modules/libc/src/cwd/cwd_log.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/cwd_log.h
+++ b/modules/libc/src/cwd/cwd_log.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/cwd_tx.c
+++ b/modules/libc/src/cwd/cwd_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/cwd_tx.h
+++ b/modules/libc/src/cwd/cwd_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/module.c
+++ b/modules/libc/src/cwd/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/cwd/module.h
+++ b/modules/libc/src/cwd/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/errno.c
+++ b/modules/libc/src/errno.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/error/error_tx.c
+++ b/modules/libc/src/error/error_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/error/error_tx.h
+++ b/modules/libc/src/error/error_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/error/module.c
+++ b/modules/libc/src/error/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/error/module.h
+++ b/modules/libc/src/error/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fcntl-tm.c
+++ b/modules/libc/src/fcntl-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fcntl.c
+++ b/modules/libc/src/fcntl.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/chrdev.c
+++ b/modules/libc/src/fildes/chrdev.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/chrdev.h
+++ b/modules/libc/src/fildes/chrdev.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/chrdev_tx.c
+++ b/modules/libc/src/fildes/chrdev_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/chrdev_tx.h
+++ b/modules/libc/src/fildes/chrdev_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/chrdev_tx_ops.c
+++ b/modules/libc/src/fildes/chrdev_tx_ops.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/chrdev_tx_ops.h
+++ b/modules/libc/src/fildes/chrdev_tx_ops.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/chrdevtab.c
+++ b/modules/libc/src/fildes/chrdevtab.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/chrdevtab.h
+++ b/modules/libc/src/fildes/chrdevtab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/dir.c
+++ b/modules/libc/src/fildes/dir.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/dir.h
+++ b/modules/libc/src/fildes/dir.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/dir_tx.c
+++ b/modules/libc/src/fildes/dir_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/dir_tx.h
+++ b/modules/libc/src/fildes/dir_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/dir_tx_ops.c
+++ b/modules/libc/src/fildes/dir_tx_ops.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
- * Copyright (c) 2020   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/dir_tx_ops.h
+++ b/modules/libc/src/fildes/dir_tx_ops.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/dirtab.c
+++ b/modules/libc/src/fildes/dirtab.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/dirtab.h
+++ b/modules/libc/src/fildes/dirtab.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fchmodop.c
+++ b/modules/libc/src/fildes/fchmodop.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fchmodop.h
+++ b/modules/libc/src/fildes/fchmodop.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fchmodoptab.c
+++ b/modules/libc/src/fildes/fchmodoptab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fchmodoptab.h
+++ b/modules/libc/src/fildes/fchmodoptab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fcntlop.c
+++ b/modules/libc/src/fildes/fcntlop.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fcntlop.h
+++ b/modules/libc/src/fildes/fcntlop.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fcntloptab.c
+++ b/modules/libc/src/fildes/fcntloptab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fcntloptab.h
+++ b/modules/libc/src/fildes/fcntloptab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fd.c
+++ b/modules/libc/src/fildes/fd.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fd.h
+++ b/modules/libc/src/fildes/fd.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fd_tx.c
+++ b/modules/libc/src/fildes/fd_tx.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fd_tx.h
+++ b/modules/libc/src/fildes/fd_tx.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fdtab.c
+++ b/modules/libc/src/fildes/fdtab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fdtab.h
+++ b/modules/libc/src/fildes/fdtab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fdtab_tx.c
+++ b/modules/libc/src/fildes/fdtab_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fdtab_tx.h
+++ b/modules/libc/src/fildes/fdtab_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fifo.c
+++ b/modules/libc/src/fildes/fifo.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fifo.h
+++ b/modules/libc/src/fildes/fifo.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fifo_tx.c
+++ b/modules/libc/src/fildes/fifo_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fifo_tx.h
+++ b/modules/libc/src/fildes/fifo_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fifo_tx_ops.c
+++ b/modules/libc/src/fildes/fifo_tx_ops.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fifo_tx_ops.h
+++ b/modules/libc/src/fildes/fifo_tx_ops.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fifotab.c
+++ b/modules/libc/src/fildes/fifotab.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fifotab.h
+++ b/modules/libc/src/fildes/fifotab.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fildes.c
+++ b/modules/libc/src/fildes/fildes.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fildes.h
+++ b/modules/libc/src/fildes/fildes.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fildes_event.c
+++ b/modules/libc/src/fildes/fildes_event.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fildes_event.h
+++ b/modules/libc/src/fildes/fildes_event.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fildes_log.c
+++ b/modules/libc/src/fildes/fildes_log.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fildes_log.h
+++ b/modules/libc/src/fildes/fildes_log.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fildes_tx.h
+++ b/modules/libc/src/fildes/fildes_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/file.c
+++ b/modules/libc/src/fildes/file.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/file.h
+++ b/modules/libc/src/fildes/file.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
- * Copyright (c) 2020   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/file_tx.c
+++ b/modules/libc/src/fildes/file_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/file_tx.h
+++ b/modules/libc/src/fildes/file_tx.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/file_tx_ops.c
+++ b/modules/libc/src/fildes/file_tx_ops.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/file_tx_ops.h
+++ b/modules/libc/src/fildes/file_tx_ops.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
- * Copyright (c) 2020   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/filebuf.c
+++ b/modules/libc/src/fildes/filebuf.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2020   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/filebuf.h
+++ b/modules/libc/src/fildes/filebuf.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2020   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/filebuf_id.c
+++ b/modules/libc/src/fildes/filebuf_id.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/filebuf_id.h
+++ b/modules/libc/src/fildes/filebuf_id.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
- * Copyright (c) 2020   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/filebuftab.c
+++ b/modules/libc/src/fildes/filebuftab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2020   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/filebuftab.h
+++ b/modules/libc/src/fildes/filebuftab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2020   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fileid.c
+++ b/modules/libc/src/fildes/fileid.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/fileid.h
+++ b/modules/libc/src/fildes/fileid.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/filetab.c
+++ b/modules/libc/src/fildes/filetab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/filetab.h
+++ b/modules/libc/src/fildes/filetab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/ioop.c
+++ b/modules/libc/src/fildes/ioop.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/ioop.h
+++ b/modules/libc/src/fildes/ioop.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/iooptab.c
+++ b/modules/libc/src/fildes/iooptab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/iooptab.h
+++ b/modules/libc/src/fildes/iooptab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/module.c
+++ b/modules/libc/src/fildes/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/module.h
+++ b/modules/libc/src/fildes/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/openop.c
+++ b/modules/libc/src/fildes/openop.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/openop.h
+++ b/modules/libc/src/fildes/openop.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/openoptab.c
+++ b/modules/libc/src/fildes/openoptab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/openoptab.h
+++ b/modules/libc/src/fildes/openoptab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipebuf.c
+++ b/modules/libc/src/fildes/pipebuf.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipebuf.h
+++ b/modules/libc/src/fildes/pipebuf.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipebuf_tx.c
+++ b/modules/libc/src/fildes/pipebuf_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipebuf_tx.h
+++ b/modules/libc/src/fildes/pipebuf_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipebuftab.c
+++ b/modules/libc/src/fildes/pipebuftab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipebuftab.h
+++ b/modules/libc/src/fildes/pipebuftab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipeop.c
+++ b/modules/libc/src/fildes/pipeop.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipeop.h
+++ b/modules/libc/src/fildes/pipeop.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipeoptab.c
+++ b/modules/libc/src/fildes/pipeoptab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/pipeoptab.h
+++ b/modules/libc/src/fildes/pipeoptab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/range.c
+++ b/modules/libc/src/fildes/range.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/range.h
+++ b/modules/libc/src/fildes/range.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regfile.c
+++ b/modules/libc/src/fildes/regfile.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regfile.h
+++ b/modules/libc/src/fildes/regfile.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regfile_tx.c
+++ b/modules/libc/src/fildes/regfile_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regfile_tx.h
+++ b/modules/libc/src/fildes/regfile_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regfile_tx_ops.c
+++ b/modules/libc/src/fildes/regfile_tx_ops.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regfile_tx_ops.h
+++ b/modules/libc/src/fildes/regfile_tx_ops.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regfiletab.c
+++ b/modules/libc/src/fildes/regfiletab.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regfiletab.h
+++ b/modules/libc/src/fildes/regfiletab.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/region.c
+++ b/modules/libc/src/fildes/region.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/region.h
+++ b/modules/libc/src/fildes/region.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regiontab.c
+++ b/modules/libc/src/fildes/regiontab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/regiontab.h
+++ b/modules/libc/src/fildes/regiontab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/rwcounter.c
+++ b/modules/libc/src/fildes/rwcounter.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/rwcounter.h
+++ b/modules/libc/src/fildes/rwcounter.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/rwcountermap.c
+++ b/modules/libc/src/fildes/rwcountermap.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/rwcountermap.h
+++ b/modules/libc/src/fildes/rwcountermap.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/rwlockmap.c
+++ b/modules/libc/src/fildes/rwlockmap.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/rwlockmap.h
+++ b/modules/libc/src/fildes/rwlockmap.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekbuf.c
+++ b/modules/libc/src/fildes/seekbuf.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekbuf.h
+++ b/modules/libc/src/fildes/seekbuf.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekbuf_tx.c
+++ b/modules/libc/src/fildes/seekbuf_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekbuf_tx.h
+++ b/modules/libc/src/fildes/seekbuf_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekbuftab.c
+++ b/modules/libc/src/fildes/seekbuftab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekbuftab.h
+++ b/modules/libc/src/fildes/seekbuftab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekop.c
+++ b/modules/libc/src/fildes/seekop.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekop.h
+++ b/modules/libc/src/fildes/seekop.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekoptab.c
+++ b/modules/libc/src/fildes/seekoptab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/seekoptab.h
+++ b/modules/libc/src/fildes/seekoptab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/sockbuf.c
+++ b/modules/libc/src/fildes/sockbuf.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/sockbuf.h
+++ b/modules/libc/src/fildes/sockbuf.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/sockbuf_tx.c
+++ b/modules/libc/src/fildes/sockbuf_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/sockbuf_tx.h
+++ b/modules/libc/src/fildes/sockbuf_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/sockbuftab.c
+++ b/modules/libc/src/fildes/sockbuftab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/sockbuftab.h
+++ b/modules/libc/src/fildes/sockbuftab.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2019-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/socket.c
+++ b/modules/libc/src/fildes/socket.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/socket.h
+++ b/modules/libc/src/fildes/socket.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/socket_tx.c
+++ b/modules/libc/src/fildes/socket_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/socket_tx.h
+++ b/modules/libc/src/fildes/socket_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/socket_tx_ops.c
+++ b/modules/libc/src/fildes/socket_tx_ops.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2020  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/socket_tx_ops.h
+++ b/modules/libc/src/fildes/socket_tx_ops.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/sockettab.c
+++ b/modules/libc/src/fildes/sockettab.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/fildes/sockettab.h
+++ b/modules/libc/src/fildes/sockettab.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
- * Copyright (c) 2020       Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/libc.c
+++ b/modules/libc/src/libc.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/libc.h
+++ b/modules/libc/src/libc.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale-tm.c
+++ b/modules/libc/src/locale-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale.c
+++ b/modules/libc/src/locale.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/locale.c
+++ b/modules/libc/src/locale/locale.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/locale.h
+++ b/modules/libc/src/locale/locale.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/locale_event.c
+++ b/modules/libc/src/locale/locale_event.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/locale_event.h
+++ b/modules/libc/src/locale/locale_event.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/locale_log.c
+++ b/modules/libc/src/locale/locale_log.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/locale_log.h
+++ b/modules/libc/src/locale/locale_log.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/locale_tx.c
+++ b/modules/libc/src/locale/locale_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/locale_tx.h
+++ b/modules/libc/src/locale/locale_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/module.c
+++ b/modules/libc/src/locale/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/locale/module.h
+++ b/modules/libc/src/locale/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/sched.c
+++ b/modules/libc/src/sched.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/signal/module.c
+++ b/modules/libc/src/signal/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/signal/module.h
+++ b/modules/libc/src/signal/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/signal/signal_tx.c
+++ b/modules/libc/src/signal/signal_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/signal/signal_tx.h
+++ b/modules/libc/src/signal/signal_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/signal/sigstate.c
+++ b/modules/libc/src/signal/sigstate.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/signal/sigstate.h
+++ b/modules/libc/src/signal/sigstate.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/stdio-tm.c
+++ b/modules/libc/src/stdio-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/stdio.c
+++ b/modules/libc/src/stdio.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/stdlib-tm.c
+++ b/modules/libc/src/stdlib-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/stdlib.c
+++ b/modules/libc/src/stdlib.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/string-tm.c
+++ b/modules/libc/src/string-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/string.c
+++ b/modules/libc/src/string.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/sys_socket-tm.c
+++ b/modules/libc/src/sys_socket-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/sys_socket.c
+++ b/modules/libc/src/sys_socket.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/sys_stat-tm.c
+++ b/modules/libc/src/sys_stat-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/sys_stat.c
+++ b/modules/libc/src/sys_stat.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/time.c
+++ b/modules/libc/src/time.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/unistd-tm.c
+++ b/modules/libc/src/unistd-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/src/unistd.c
+++ b/modules/libc/src/unistd.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/tests/Makefile.am
+++ b/modules/libc/tests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/tests/pubapi/Makefile.am
+++ b/modules/libc/tests/pubapi/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libc/tests/pubapi/allocator-pubapi-t1-valgrind.test
+++ b/modules/libc/tests/pubapi/allocator-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/allocator-pubapi-t1.test
+++ b/modules/libc/tests/pubapi/allocator-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/allocator-pubapi-t4.test
+++ b/modules/libc/tests/pubapi/allocator-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/allocator_pubapi.c
+++ b/modules/libc/tests/pubapi/allocator_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/cwd-pubapi-t1-valgrind.test
+++ b/modules/libc/tests/pubapi/cwd-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/cwd-pubapi-t1.test
+++ b/modules/libc/tests/pubapi/cwd-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/cwd-pubapi-t4.test
+++ b/modules/libc/tests/pubapi/cwd-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/cwd_pubapi.c
+++ b/modules/libc/tests/pubapi/cwd_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/fildes-pubapi-t1-valgrind.test
+++ b/modules/libc/tests/pubapi/fildes-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/fildes-pubapi-t1.test
+++ b/modules/libc/tests/pubapi/fildes-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/fildes-pubapi-t4.test
+++ b/modules/libc/tests/pubapi/fildes-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/fildes_pubapi.c
+++ b/modules/libc/tests/pubapi/fildes_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/locale_h-pubapi-t1-valgrind.test
+++ b/modules/libc/tests/pubapi/locale_h-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/locale_h-pubapi-t1.test
+++ b/modules/libc/tests/pubapi/locale_h-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/locale_h-pubapi-t4.test
+++ b/modules/libc/tests/pubapi/locale_h-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/locale_h_pubapi.c
+++ b/modules/libc/tests/pubapi/locale_h_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/signal-pubapi-t1-valgrind.test
+++ b/modules/libc/tests/pubapi/signal-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/signal-pubapi-t1.test
+++ b/modules/libc/tests/pubapi/signal-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/signal-pubapi-t4.test
+++ b/modules/libc/tests/pubapi/signal-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/signal_pubapi.c
+++ b/modules/libc/tests/pubapi/signal_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/signal_pubapi.supp
+++ b/modules/libc/tests/pubapi/signal_pubapi.supp
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/time_h-pubapi-t1-valgrind.test
+++ b/modules/libc/tests/pubapi/time_h-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/time_h-pubapi-t1.test
+++ b/modules/libc/tests/pubapi/time_h-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/time_h-pubapi-t4.test
+++ b/modules/libc/tests/pubapi/time_h-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libc/tests/pubapi/time_h_pubapi.c
+++ b/modules/libc/tests/pubapi/time_h_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libm/Makefile.am
+++ b/modules/libm/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/include/Makefile.am
+++ b/modules/libm/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/include/picotm/complex.h
+++ b/modules/libm/include/picotm/complex.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/include/picotm/config/picotm-libm-config.h.in
+++ b/modules/libm/include/picotm/config/picotm-libm-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/include/picotm/math-tm.h
+++ b/modules/libm/include/picotm/math-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/include/picotm/math.h
+++ b/modules/libm/include/picotm/math.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/include/picotm/picotm-libm.h
+++ b/modules/libm/include/picotm/picotm-libm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/Makefile.am
+++ b/modules/libm/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/complex.c
+++ b/modules/libm/src/complex.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/fpu_tx.c
+++ b/modules/libm/src/fpu_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/fpu_tx.h
+++ b/modules/libm/src/fpu_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/libm.c
+++ b/modules/libm/src/libm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/math-tm.c
+++ b/modules/libm/src/math-tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/math.c
+++ b/modules/libm/src/math.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/matherr.c
+++ b/modules/libm/src/matherr.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/matherr.h
+++ b/modules/libm/src/matherr.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/module.c
+++ b/modules/libm/src/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/src/module.h
+++ b/modules/libm/src/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/tests/Makefile.am
+++ b/modules/libm/tests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/tests/pubapi/Makefile.am
+++ b/modules/libm/tests/pubapi/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libm/tests/pubapi/complex-pubapi-t1-valgrind.test
+++ b/modules/libm/tests/pubapi/complex-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/complex-pubapi-t1.test
+++ b/modules/libm/tests/pubapi/complex-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/complex-pubapi-t4.test
+++ b/modules/libm/tests/pubapi/complex-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/complex_pubapi.c
+++ b/modules/libm/tests/pubapi/complex_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/math-pubapi-t1-valgrind.test
+++ b/modules/libm/tests/pubapi/math-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/math-pubapi-t1.test
+++ b/modules/libm/tests/pubapi/math-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/math-pubapi-t4.test
+++ b/modules/libm/tests/pubapi/math-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/math_pubapi.c
+++ b/modules/libm/tests/pubapi/math_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/testmacro.c
+++ b/modules/libm/tests/pubapi/testmacro.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libm/tests/pubapi/testmacro.h
+++ b/modules/libm/tests/pubapi/testmacro.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/libpthread/Makefile.am
+++ b/modules/libpthread/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libpthread/include/Makefile.am
+++ b/modules/libpthread/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libpthread/include/picotm/config/picotm-libpthread-config.h.in
+++ b/modules/libpthread/include/picotm/config/picotm-libpthread-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libpthread/include/picotm/pthread.h
+++ b/modules/libpthread/include/picotm/pthread.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libpthread/src/Makefile.am
+++ b/modules/libpthread/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/libpthread/src/pthread.c
+++ b/modules/libpthread/src/pthread.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/Makefile.am
+++ b/modules/ptrdata/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/include/Makefile.am
+++ b/modules/ptrdata/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/include/picotm/config/picotm-ptrdata-config.h.in
+++ b/modules/ptrdata/include/picotm/config/picotm-ptrdata-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/include/picotm/picotm-ptrdata.h
+++ b/modules/ptrdata/include/picotm/picotm-ptrdata.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/Makefile.am
+++ b/modules/ptrdata/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/module.c
+++ b/modules/ptrdata/src/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/module.h
+++ b/modules/ptrdata/src/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/picotm-ptrdata.c
+++ b/modules/ptrdata/src/picotm-ptrdata.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/picotm-ptrdata.h
+++ b/modules/ptrdata/src/picotm-ptrdata.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/ptrdata.c
+++ b/modules/ptrdata/src/ptrdata.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/ptrdata.h
+++ b/modules/ptrdata/src/ptrdata.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/ptrdata_tx.c
+++ b/modules/ptrdata/src/ptrdata_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/src/ptrdata_tx.h
+++ b/modules/ptrdata/src/ptrdata_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/tests/Makefile.am
+++ b/modules/ptrdata/tests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/tests/modapi/Makefile.am
+++ b/modules/ptrdata/tests/modapi/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/ptrdata/tests/modapi/ptrdata-modapi-t1-valgrind.test
+++ b/modules/ptrdata/tests/modapi/ptrdata-modapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/ptrdata/tests/modapi/ptrdata-modapi-t1.test
+++ b/modules/ptrdata/tests/modapi/ptrdata-modapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/ptrdata/tests/modapi/ptrdata-modapi-t4.test
+++ b/modules/ptrdata/tests/modapi/ptrdata-modapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/ptrdata/tests/modapi/ptrdata_modapi.c
+++ b/modules/ptrdata/tests/modapi/ptrdata_modapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/tm/Makefile.am
+++ b/modules/tm/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/include/Makefile.am
+++ b/modules/tm/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/include/picotm/config/picotm-tm-config.h.in
+++ b/modules/tm/include/picotm/config/picotm-tm-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/include/picotm/picotm-tm-ctypes.h
+++ b/modules/tm/include/picotm/picotm-tm-ctypes.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/include/picotm/picotm-tm.h
+++ b/modules/tm/include/picotm/picotm-tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/Makefile.am
+++ b/modules/tm/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/block.h
+++ b/modules/tm/src/block.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/frame.c
+++ b/modules/tm/src/frame.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/frame.h
+++ b/modules/tm/src/frame.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/framemap.c
+++ b/modules/tm/src/framemap.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/framemap.h
+++ b/modules/tm/src/framemap.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/module.c
+++ b/modules/tm/src/module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/module.h
+++ b/modules/tm/src/module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/page.c
+++ b/modules/tm/src/page.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/page.h
+++ b/modules/tm/src/page.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/tm.c
+++ b/modules/tm/src/tm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/tm.h
+++ b/modules/tm/src/tm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/vmem.c
+++ b/modules/tm/src/vmem.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/vmem.h
+++ b/modules/tm/src/vmem.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/vmem_tx.c
+++ b/modules/tm/src/vmem_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/src/vmem_tx.h
+++ b/modules/tm/src/vmem_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/tests/Makefile.am
+++ b/modules/tm/tests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/tests/pubapi/Makefile.am
+++ b/modules/tm/tests/pubapi/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/tm/tests/pubapi/tm-pubapi-t1-valgrind.test
+++ b/modules/tm/tests/pubapi/tm-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/tm/tests/pubapi/tm-pubapi-t1.test
+++ b/modules/tm/tests/pubapi/tm-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/tm/tests/pubapi/tm-pubapi-t4.test
+++ b/modules/tm/tests/pubapi/tm-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/tm/tests/pubapi/tm_pubapi.c
+++ b/modules/tm/tests/pubapi/tm_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/txlib/Makefile.am
+++ b/modules/txlib/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/Makefile.am
+++ b/modules/txlib/include/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/config/picotm-txlib-config.h.in
+++ b/modules/txlib/include/picotm/config/picotm-txlib-config.h.in
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txlib.h
+++ b/modules/txlib/include/picotm/picotm-txlib.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txlist-state.h
+++ b/modules/txlib/include/picotm/picotm-txlist-state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txlist.h
+++ b/modules/txlib/include/picotm/picotm-txlist.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txmultiset-state.h
+++ b/modules/txlib/include/picotm/picotm-txmultiset-state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txmultiset.h
+++ b/modules/txlib/include/picotm/picotm-txmultiset.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txqueue-state.h
+++ b/modules/txlib/include/picotm/picotm-txqueue-state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txqueue.h
+++ b/modules/txlib/include/picotm/picotm-txqueue.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txstack-state.h
+++ b/modules/txlib/include/picotm/picotm-txstack-state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/include/picotm/picotm-txstack.h
+++ b/modules/txlib/include/picotm/picotm-txstack.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/Makefile.am
+++ b/modules/txlib/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlib_event.c
+++ b/modules/txlib/src/txlib_event.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlib_event.h
+++ b/modules/txlib/src/txlib_event.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlib_module.c
+++ b/modules/txlib/src/txlib_module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlib_module.h
+++ b/modules/txlib/src/txlib_module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlib_tx.c
+++ b/modules/txlib/src/txlib_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlib_tx.h
+++ b/modules/txlib/src/txlib_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlist.c
+++ b/modules/txlib/src/txlist.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlist.h
+++ b/modules/txlib/src/txlist.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlist_entry.c
+++ b/modules/txlib/src/txlist_entry.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlist_entry.h
+++ b/modules/txlib/src/txlist_entry.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlist_state.c
+++ b/modules/txlib/src/txlist_state.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlist_state.h
+++ b/modules/txlib/src/txlist_state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlist_tx.c
+++ b/modules/txlib/src/txlist_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txlist_tx.h
+++ b/modules/txlib/src/txlist_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txmultiset.c
+++ b/modules/txlib/src/txmultiset.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txmultiset.h
+++ b/modules/txlib/src/txmultiset.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txmultiset_entry.c
+++ b/modules/txlib/src/txmultiset_entry.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txmultiset_entry.h
+++ b/modules/txlib/src/txmultiset_entry.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txmultiset_state.c
+++ b/modules/txlib/src/txmultiset_state.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txmultiset_state.h
+++ b/modules/txlib/src/txmultiset_state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txmultiset_tx.c
+++ b/modules/txlib/src/txmultiset_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txmultiset_tx.h
+++ b/modules/txlib/src/txmultiset_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txqueue.c
+++ b/modules/txlib/src/txqueue.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txqueue.h
+++ b/modules/txlib/src/txqueue.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txqueue_entry.c
+++ b/modules/txlib/src/txqueue_entry.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txqueue_entry.h
+++ b/modules/txlib/src/txqueue_entry.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txqueue_state.c
+++ b/modules/txlib/src/txqueue_state.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txqueue_state.h
+++ b/modules/txlib/src/txqueue_state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txqueue_tx.c
+++ b/modules/txlib/src/txqueue_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txqueue_tx.h
+++ b/modules/txlib/src/txqueue_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txstack.c
+++ b/modules/txlib/src/txstack.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txstack.h
+++ b/modules/txlib/src/txstack.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txstack_entry.c
+++ b/modules/txlib/src/txstack_entry.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txstack_entry.h
+++ b/modules/txlib/src/txstack_entry.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txstack_state.c
+++ b/modules/txlib/src/txstack_state.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txstack_state.h
+++ b/modules/txlib/src/txstack_state.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txstack_tx.c
+++ b/modules/txlib/src/txstack_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/src/txstack_tx.h
+++ b/modules/txlib/src/txstack_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/tests/Makefile.am
+++ b/modules/txlib/tests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/tests/pubapi/Makefile.am
+++ b/modules/txlib/tests/pubapi/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/modules/txlib/tests/pubapi/txlist-pubapi-t1-valgrind.test
+++ b/modules/txlib/tests/pubapi/txlist-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txlist-pubapi-t1.test
+++ b/modules/txlib/tests/pubapi/txlist-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txlist-pubapi-t4.test
+++ b/modules/txlib/tests/pubapi/txlist-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txlist_pubapi.c
+++ b/modules/txlib/tests/pubapi/txlist_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txmultiset-pubapi-t1-valgrind.test
+++ b/modules/txlib/tests/pubapi/txmultiset-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txmultiset-pubapi-t1.test
+++ b/modules/txlib/tests/pubapi/txmultiset-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txmultiset-pubapi-t4.test
+++ b/modules/txlib/tests/pubapi/txmultiset-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txmultiset_pubapi.c
+++ b/modules/txlib/tests/pubapi/txmultiset_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txqueue-pubapi-t1-valgrind.test
+++ b/modules/txlib/tests/pubapi/txqueue-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txqueue-pubapi-t1.test
+++ b/modules/txlib/tests/pubapi/txqueue-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txqueue-pubapi-t4.test
+++ b/modules/txlib/tests/pubapi/txqueue-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txqueue_pubapi.c
+++ b/modules/txlib/tests/pubapi/txqueue_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txstack-pubapi-t1-valgrind.test
+++ b/modules/txlib/tests/pubapi/txstack-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txstack-pubapi-t1.test
+++ b/modules/txlib/tests/pubapi/txstack-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txstack-pubapi-t4.test
+++ b/modules/txlib/tests/pubapi/txstack-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/txlib/tests/pubapi/txstack_pubapi.c
+++ b/modules/txlib/tests/pubapi/txstack_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm-error.c
+++ b/src/picotm-error.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm-lib-rwlock.c
+++ b/src/picotm-lib-rwlock.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
- * Copyright (c) 2019   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm-lib-rwlock.h
+++ b/src/picotm-lib-rwlock.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm-lib-rwstate.c
+++ b/src/picotm-lib-rwstate.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm-lib-shared-ref-obj.c
+++ b/src/picotm-lib-shared-ref-obj.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm-lib-shared-treemap.c
+++ b/src/picotm-lib-shared-treemap.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm-lib-tab.c
+++ b/src/picotm-lib-tab.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm-lib-treemap.c
+++ b/src/picotm-lib-treemap.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm.c
+++ b/src/picotm.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm.h
+++ b/src/picotm.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_event.c
+++ b/src/picotm_event.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_event.h
+++ b/src/picotm_event.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_lock_manager.c
+++ b/src/picotm_lock_manager.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
- * Copyright (c) 2019   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_lock_manager.h
+++ b/src/picotm_lock_manager.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
- * Copyright (c) 2019   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_lock_owner.c
+++ b/src/picotm_lock_owner.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_lock_owner.h
+++ b/src/picotm_lock_owner.h
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
- * Copyright (c) 2019   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_log.c
+++ b/src/picotm_log.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_log.h
+++ b/src/picotm_log.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_module.c
+++ b/src/picotm_module.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_module.h
+++ b/src/picotm_module.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_os_cond.c
+++ b/src/picotm_os_cond.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_os_cond.h
+++ b/src/picotm_os_cond.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_os_mutex.c
+++ b/src/picotm_os_mutex.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_os_mutex.h
+++ b/src/picotm_os_mutex.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_os_rwlock.c
+++ b/src/picotm_os_rwlock.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_os_rwlock.h
+++ b/src/picotm_os_rwlock.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_os_timespec.c
+++ b/src/picotm_os_timespec.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_os_timespec.h
+++ b/src/picotm_os_timespec.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_tx.c
+++ b/src/picotm_tx.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2019  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/picotm_tx.h
+++ b/src/picotm_tx.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/table.c
+++ b/src/table.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/table.h
+++ b/src/table.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/tests/env/Makefile.am
+++ b/tests/env/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/tests/env/run_test_under_valgrind
+++ b/tests/env/run_test_under_valgrind
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/env/tests-env.sh.in
+++ b/tests/env/tests-env.sh.in
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/libsafeblk/Makefile.am
+++ b/tests/libsafeblk/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/compat/pthread_barrier.c
+++ b/tests/libsafeblk/compat/pthread_barrier.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/compat/pthread_barrier.h
+++ b/tests/libsafeblk/compat/pthread_barrier.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/compat/static_assert.h
+++ b/tests/libsafeblk/compat/static_assert.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/compat/temp_failure_retry.h
+++ b/tests/libsafeblk/compat/temp_failure_retry.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_fcntl.c
+++ b/tests/libsafeblk/safe_fcntl.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_fcntl.h
+++ b/tests/libsafeblk/safe_fcntl.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_pthread.c
+++ b/tests/libsafeblk/safe_pthread.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_pthread.h
+++ b/tests/libsafeblk/safe_pthread.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_sched.c
+++ b/tests/libsafeblk/safe_sched.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_sched.h
+++ b/tests/libsafeblk/safe_sched.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_stdio.c
+++ b/tests/libsafeblk/safe_stdio.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_stdio.h
+++ b/tests/libsafeblk/safe_stdio.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_stdlib.c
+++ b/tests/libsafeblk/safe_stdlib.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_stdlib.h
+++ b/tests/libsafeblk/safe_stdlib.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_sys_stat.c
+++ b/tests/libsafeblk/safe_sys_stat.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_sys_stat.h
+++ b/tests/libsafeblk/safe_sys_stat.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_sys_time.c
+++ b/tests/libsafeblk/safe_sys_time.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_sys_time.h
+++ b/tests/libsafeblk/safe_sys_time.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_time.c
+++ b/tests/libsafeblk/safe_time.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_time.h
+++ b/tests/libsafeblk/safe_time.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_unistd.c
+++ b/tests/libsafeblk/safe_unistd.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safe_unistd.h
+++ b/tests/libsafeblk/safe_unistd.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safeblk.c
+++ b/tests/libsafeblk/safeblk.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libsafeblk/safeblk.h
+++ b/tests/libsafeblk/safeblk.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtap/Makefile.am
+++ b/tests/libtap/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtap/tap.c
+++ b/tests/libtap/tap.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtap/tap.h
+++ b/tests/libtap/tap.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtap/taputils.c
+++ b/tests/libtap/taputils.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtap/taputils.h
+++ b/tests/libtap/taputils.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/Makefile.am
+++ b/tests/libtests/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/opts.c
+++ b/tests/libtests/opts.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/opts.h
+++ b/tests/libtests/opts.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/ptr.h
+++ b/tests/libtests/ptr.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/pubapi.c
+++ b/tests/libtests/pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/pubapi.h
+++ b/tests/libtests/pubapi.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/sysenv.c
+++ b/tests/libtests/sysenv.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/sysenv.h
+++ b/tests/libtests/sysenv.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2018   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/tempfile.c
+++ b/tests/libtests/tempfile.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/tempfile.h
+++ b/tests/libtests/tempfile.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/test.c
+++ b/tests/libtests/test.c
@@ -1,7 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
- * Copyright (c) 2019   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/test.h
+++ b/tests/libtests/test.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/testhlp.c
+++ b/tests/libtests/testhlp.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/testhlp.h
+++ b/tests/libtests/testhlp.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/thread.c
+++ b/tests/libtests/thread.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/libtests/thread.h
+++ b/tests/libtests/thread.h
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017   Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/pubapi/Makefile.am
+++ b/tests/pubapi/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/tests/pubapi/core-pubapi-t1-valgrind.test
+++ b/tests/pubapi/core-pubapi-t1-valgrind.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2018    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/pubapi/core-pubapi-t1.test
+++ b/tests/pubapi/core-pubapi-t1.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/pubapi/core-pubapi-t4.test
+++ b/tests/pubapi/core-pubapi-t4.test
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/pubapi/core_pubapi.c
+++ b/tests/pubapi/core_pubapi.c
@@ -1,6 +1,5 @@
 /*
  * picotm - A system-level transaction manager
- * Copyright (c) 2017-2018  Thomas Zimmermann
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,6 +1,5 @@
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017-2018   Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tools/mkrelease.pl
+++ b/tools/mkrelease.pl
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 #
 # picotm - A system-level transaction manager
-# Copyright (c) 2017    Thomas Zimmermann
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This is just churn and keeps on changing. Authors are listed in the revision control's history. To acknowledge special contributors, an AUTHORS file would be more appropriate.