### PR TITLE
Distinct file ids

### DIFF
--- a/m4-local/config_libc.m4
+++ b/m4-local/config_libc.m4
@@ -324,6 +324,18 @@ AC_DEFUN([_CHECK_LIBC_SYS_STAT_H], [
     ])
 ])
 
+AC_DEFUN([_CHECK_LIBC_SYS_SYSCALL_H], [
+    AC_CHECK_HEADERS([sys/syscall.h])
+    AS_VAR_IF([ac_cv_header_sys_syscall_h], [yes], [
+
+        #
+        # Public interfaces
+        #
+
+        _CHECK_MODULE_INTF([libc], [syscall], [[@%:@include <sys/syscall.h>]])
+    ])
+])
+
 AC_DEFUN([_CHECK_LIBC_SYS_TYPES_H], [
     AC_CHECK_HEADERS([sys/types.h])
     AS_VAR_IF([ac_cv_header_sys_types_h], [yes], [
@@ -455,6 +467,7 @@ AC_DEFUN([_CONFIG_LIBC], [
         _CHECK_LIBC_STRING_H
         _CHECK_LIBC_SYS_SOCKET_H
         _CHECK_LIBC_SYS_STAT_H
+        _CHECK_LIBC_SYS_SYSCALL_H
         _CHECK_LIBC_SYS_TYPES_H
         _CHECK_LIBC_TIME_H
         _CHECK_LIBC_UNISTD_H

--- a/modules/libc/src/Makefile.am
+++ b/modules/libc/src/Makefile.am
@@ -34,6 +34,8 @@ libpicotm_c_la_SOURCES = allocator/allocator_event.c \
                          allocator/allocator_tx.h \
                          allocator/module.c \
                          allocator/module.h \
+                         compat/cmp_eq_files.c \
+                         compat/cmp_eq_files.h \
                          compat/get_current_dir_name.c \
                          compat/get_current_dir_name.h \
                          compat/malloc_usable_size.c \

--- a/modules/libc/src/compat/cmp_eq_files.c
+++ b/modules/libc/src/compat/cmp_eq_files.c
@@ -1,0 +1,64 @@
+/*
+ * picotm - A system-level transaction manager
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "cmp_eq_files.h"
+#include "picotm/picotm-error.h"
+#if defined(HAVE_SYS_SYSCALL_H) && HAVE_SYS_SYSCALL_H
+#include <sys/syscall.h>
+#endif
+
+#if defined(SYS_kcmp)
+#include <errno.h>
+#include <linux/kcmp.h>
+#include <unistd.h>
+
+static bool
+cmp_eq_files_kcmp(int lhs, int rhs, struct picotm_error *error)
+{
+    pid_t pid = getpid();
+
+    int ret = syscall(SYS_kcmp, pid, pid, KCMP_FILE, lhs, rhs);
+    switch (ret) {
+        case 0:
+            return true;
+        case 1:
+        case 2:
+        case 3: /* unordered sequences should not happen in our use case */
+            return false;
+        case -1: /* errors */
+            picotm_error_set_errno(error, errno);
+            break;
+        default:
+            picotm_error_set_error_code(error, PICOTM_GENERAL_ERROR);
+            break;
+    }
+
+    return false;
+}
+#endif
+
+bool
+cmp_eq_files(int lhs, int rhs, struct picotm_error* error)
+{
+#if defined(SYS_kcmp)
+    return cmp_eq_files_kcmp(lhs, rhs, error);
+#else
+#error file_id_cmp not implemented
+#endif
+}

--- a/modules/libc/src/compat/cmp_eq_files.c
+++ b/modules/libc/src/compat/cmp_eq_files.c
@@ -19,6 +19,7 @@
 
 #include "cmp_eq_files.h"
 #include "picotm/picotm-error.h"
+#include <fcntl.h>
 #if defined(HAVE_SYS_SYSCALL_H) && HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
 #endif
@@ -53,11 +54,44 @@ cmp_eq_files_kcmp(int lhs, int rhs, struct picotm_error *error)
 }
 #endif
 
+#if defined(F_DUPFD_QUERY)
+#include <errno.h>
+
+static bool cmp_eq_files_dupfd(int lhs, int rhs, struct picotm_error *error)
+{
+    int ret = fcntl(lhs, F_DUPFD_QUERY, rhs);
+    if (ret < 0) {
+        picotm_error_set_errno(error, errno);
+        return false;
+    }
+
+    return !!ret;
+}
+#endif
+
 bool
 cmp_eq_files(int lhs, int rhs, struct picotm_error* error)
 {
 #if defined(SYS_kcmp)
-    return cmp_eq_files_kcmp(lhs, rhs, error);
+    bool eq = cmp_eq_files_kcmp(lhs, rhs, error);
+#if defined(F_DUPFD_QUERY)
+    if (picotm_error_is_set(error)) {
+        switch(error->status) {
+            case PICOTM_ERRNO:
+                if (error->value.errno_hint == -ENOSYS) {
+                    picotm_error_clear(error);
+                    /* kcmp isn't available, but maybe F_DUPFD_QUERY is */
+                    return cmp_eq_files_dupfd(lhs, rhs, error);
+                }
+                [[fallthrough]];
+            default:
+                break;
+        }
+    }
+#endif
+    return eq;
+#elif defined(F_DUPFD_QUERY)
+    return cmp_eq_files_dupfd(lhs, rhs, error);
 #else
 #error file_id_cmp not implemented
 #endif

--- a/modules/libc/src/compat/cmp_eq_files.h
+++ b/modules/libc/src/compat/cmp_eq_files.h
@@ -1,0 +1,30 @@
+/*
+ * picotm - A system-level transaction manager
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+struct picotm_error;
+
+/**
+ * \brief Tests two file descriptor's files for equality
+ */
+bool
+cmp_eq_files(int lhs, int rhs, struct picotm_error* error);

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -546,8 +546,7 @@ true_if_eq_id_cb(const struct picotm_slist* item, void* data)
     const struct file_id* id = data;
     assert(id);
 
-    int cmp = file_id_cmp(&file_tx->file->id, id);
-    return !cmp;
+    return file_id_cmp_eq(&file_tx->file->id, id);
 }
 
 static bool

--- a/modules/libc/src/fildes/fildes_tx.c
+++ b/modules/libc/src/fildes/fildes_tx.c
@@ -651,11 +651,7 @@ get_file_tx(struct fildes_tx* self, int fildes,
             enum picotm_libc_file_type type,
             struct picotm_error* error)
 {
-    struct file_id id;
-    file_id_init_from_fildes(&id, fildes, error);
-    if (picotm_error_is_set(error)) {
-        return nullptr;
-    }
+    struct file_id id = FILE_ID_INITIALIZER(fildes);
 
     /* Let's see if we already have the file in use.*/
 

--- a/modules/libc/src/fildes/file.c
+++ b/modules/libc/src/fildes/file.c
@@ -110,10 +110,7 @@ cond_ref(struct picotm_shared_ref16_obj* ref_obj, void* data,
     const struct file_id* lhs = &self->id;
     const struct file_id* rhs = ref_obj_data->id;
 
-    if (ref_obj_data->new_file)
-        ref_obj_data->found = file_id_cmp_eq_fildes(lhs, rhs, error);
-    else
-        ref_obj_data->found = file_id_cmp_eq(lhs, rhs);
+    ref_obj_data->found = file_id_cmp_eq(lhs, rhs, error);
 
     return ref_obj_data->found;
 }
@@ -126,10 +123,9 @@ file_ref_or_set_up_if_id(struct file* self, int fildes, bool new_file,
     assert(self);
 
     struct ref_obj_data data = REF_OBJ_DATA_INITIALIZER(id, fildes, new_file);
-    picotm_shared_ref16_obj_up(&self->ref_obj, &data, cond_ref, first_ref,
-                               error);
+    picotm_shared_ref16_obj_up(&self->ref_obj, &data, cond_ref, first_ref, error);
     if (picotm_error_is_set(error)) {
-        return 0;
+        return false;
     }
 
     return data.found;

--- a/modules/libc/src/fildes/file.c
+++ b/modules/libc/src/fildes/file.c
@@ -78,10 +78,7 @@ first_ref(struct picotm_shared_ref16_obj* ref_obj, void* data,
     const struct ref_obj_data* ref_obj_data = data;
     assert(ref_obj_data);
 
-    file_id_init_from_fildes(&self->id, ref_obj_data->fildes, error);
-    if (picotm_error_is_set(error)) {
-        return;
-    }
+    file_id_init(&self->id, ref_obj_data->fildes);
 }
 
 void

--- a/modules/libc/src/fildes/file.h
+++ b/modules/libc/src/fildes/file.h
@@ -78,10 +78,9 @@ file_ref_or_set_up(struct file* self, int fildes, struct picotm_error* error);
  * \param       new_file    True if the file was create by the transaction;
  *                          false otherwise.
  * \param[out]  error       Returns an error ot the caller.
- * \returns A value less than, equal to, or greater than if the file's id is
- *          less than, equal to, or greater than the given id.
+ * \returns True if the reference has been acquired, or false otherwise.
  */
-int
+bool
 file_ref_or_set_up_if_id(struct file* self, int fildes, bool new_file,
                          const struct file_id* id,
                          struct picotm_error* error);
@@ -101,10 +100,9 @@ file_ref(struct file* self, struct picotm_error* error);
  * \param   id          The id to compare to.
  * \param   new_file    True if the file was create by the transaction;
  *                      false otherwise.
- * \returns A value less than, equal to, or greater than if the file's id
- *          is less than, equal to, or greater than the given id.
+ * \returns True if the reference has been acquired, or false otherwise.
  */
-int
+bool
 file_ref_if_id(struct file* self, const struct file_id* id, bool new_file,
                struct picotm_error* error);
 

--- a/modules/libc/src/fildes/fileid.c
+++ b/modules/libc/src/fildes/fileid.c
@@ -86,39 +86,39 @@ cmp_fildes(int lhs, int rhs)
     return (lhs > rhs) - (lhs < rhs);
 }
 
-int
-file_id_cmp(const struct file_id* lhs, const struct file_id* rhs)
+bool
+file_id_cmp_eq(const struct file_id* lhs, const struct file_id* rhs)
 {
     int cmp = cmp_dev_t(lhs->dev, rhs->dev);
     if (cmp)
-        return cmp;
+        return false;
 
     cmp = cmp_ino_t(lhs->ino, rhs->ino);
     if (cmp)
-        return cmp;
+        return false;
 
-    return cmp_fildes(lhs->fildes, rhs->fildes);
+    return !cmp_fildes(lhs->fildes, rhs->fildes);
 }
 
-int
+bool
 file_id_cmp_eq_fildes(const struct file_id lhs[static 1],
                       const struct file_id rhs[static 1],
                       struct picotm_error error[static 1])
 {
     int cmp = cmp_dev_t(lhs->dev, rhs->dev);
     if (cmp)
-        return cmp;
+        return false;
 
     cmp = cmp_ino_t(lhs->ino, rhs->ino);
     if (cmp)
-        return cmp;
+        return false;
 
     cmp = cmp_fildes(lhs->fildes, rhs->fildes);
     if (cmp) {
         /* file descriptors are different; return error */
         picotm_error_set_errno(error, EBADF);
-        return cmp;
+        return false;
     }
 
-    return 0;
+    return true;
 }

--- a/modules/libc/src/fildes/fileid.c
+++ b/modules/libc/src/fildes/fileid.c
@@ -20,43 +20,18 @@
 #include "fileid.h"
 #include "compat/cmp_eq_files.h"
 #include <assert.h>
-#include <errno.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 void
-file_id_init(struct file_id* self, dev_t dev, ino_t ino)
+file_id_init(struct file_id* self, int fildes)
 {
     assert(self);
 
-    self->dev = dev;
-    self->ino = ino;
-}
-
-void
-file_id_init_from_fildes(struct file_id* self, int fildes,
-                         struct picotm_error* error)
-{
-    assert(self);
-
-    struct stat buf;
-
-    int res = fstat(fildes, &buf);
-    if (res < 0) {
-        picotm_error_set_errno(error, errno);
-        return;
-    }
-
-    self->dev = buf.st_dev;
-    self->ino = buf.st_ino;
     self->fildes = fildes;
 }
 
 void
 file_id_clear(struct file_id* self)
 {
-    self->dev = (dev_t)-1;
-    self->ino = (ino_t)-1;
     self->fildes = -1;
 }
 
@@ -65,9 +40,7 @@ file_id_is_empty(const struct file_id* self)
 {
     assert(self);
 
-    return (self->dev == (dev_t)-1) &&
-           (self->ino == (ino_t)-1) &&
-           (self->fildes == -1);
+    return (self->fildes == -1);
 }
 
 static int

--- a/modules/libc/src/fildes/fileid.h
+++ b/modules/libc/src/fildes/fileid.h
@@ -21,7 +21,6 @@
 
 #include "picotm/picotm-error.h"
 #include <stdbool.h>
-#include <sys/types.h>
 
 /**
  * \cond impl || libc_impl || libc_impl_fd
@@ -34,39 +33,26 @@
 /**
  * A unique id for a file.
  *
- * By default, an open file does not have an id by itself. Picotm
- * constructs the id from the id of the file's file buffer and the
- * file descriptor that refers to the file.
- *
- * If two file descriptors refer to the same file, they create two
- * different ids. Even though the file may be the same, these ids
- * must compare as *different.* It's a shortcoming resulting from the
- * non-existence of unique ids for open files.
+ * An open file does not have an id by itself. Picotm constructs
+ * the id by querying the operating system for equality of the file
+ * descriptor's file.
  */
 struct file_id {
-    dev_t  dev;
-    ino_t  ino;
     int fildes;
 };
 
-/**
- * Initializes a file id with values
- * \param[out]  self    The file id to initialize.
- * \param       dev     The device number.
- * \param       ino     The inode number.
- */
-void
-file_id_init(struct file_id* self, dev_t dev, ino_t ino);
+#define FILE_ID_INITIALIZER(__fildes)   \
+    {                                   \
+        .fildes = (__fildes),           \
+    }
 
 /**
  * \brief Initializes a file id from file descriptor.
  * \param[out]  self    The file id to initialize.
  * \param       fildes  The file descriptor.
- * \param[out]  error   Returns an error to the caller.
  */
 void
-file_id_init_from_fildes(struct file_id* self, int fildes,
-                            struct picotm_error* error);
+file_id_init(struct file_id* self, int fildes);
 
 /**
  * \brief Clears a file id.

--- a/modules/libc/src/fildes/fileid.h
+++ b/modules/libc/src/fildes/fileid.h
@@ -94,17 +94,4 @@ file_id_is_empty(const struct file_id* self);
  * always compare as equal.
  */
 bool
-file_id_cmp_eq(const struct file_id* lhs, const struct file_id* rhs);
-
-/**
- * \brief Compares two file ids for equality. Signals
- *        an error if file descriptors are different.
- * \param       lhs     The left-hand-side file id.
- * \param       rhs     The right-hand-side file id.
- * \param[out]  error   Returns an error to the caller.
- * \returns True if the file ids are equal, or false otherwise.
- */
-bool
-file_id_cmp_eq_fildes(const struct file_id lhs[static 1],
-                      const struct file_id rhs[static 1],
-                      struct picotm_error error[static 1]);
+file_id_cmp_eq(const struct file_id* lhs, const struct file_id* rhs, struct picotm_error* error);

--- a/modules/libc/src/fildes/fileid.h
+++ b/modules/libc/src/fildes/fileid.h
@@ -84,27 +84,27 @@ bool
 file_id_is_empty(const struct file_id* self);
 
 /**
- * \return Compares two file ids, returns value as for strcmp.
+ * \brief Compares two file ids for equality.
  * \param   lhs The left-hand-side file id.
  * \param   rhs The right-hand-side file id.
- * \returns A value less than, equal to or greater than zero of the value
- *          of lhs is less than, equal to or greater than the value of
- *          rhws.
+ * \param[out]  error   Returns an error to the caller.
+ * \returns True if the file ids are equal, or false otherwise.
+ *
+ * Compares file ids. Also works for file ids that have been cleared, which
+ * always compare as equal.
  */
-int
-file_id_cmp(const struct file_id* lhs, const struct file_id* rhs);
+bool
+file_id_cmp_eq(const struct file_id* lhs, const struct file_id* rhs);
 
 /**
- * \brief Compares two file ids, returns value as for strcmp. Signals
+ * \brief Compares two file ids for equality. Signals
  *        an error if file descriptors are different.
  * \param       lhs     The left-hand-side file id.
  * \param       rhs     The right-hand-side file id.
  * \param[out]  error   Returns an error to the caller.
- * \returns A value less than, equal to or greater than zero if the value
- *          of lhs is less than, equal to or greater than the value of
- *          rhs.
+ * \returns True if the file ids are equal, or false otherwise.
  */
-int
+bool
 file_id_cmp_eq_fildes(const struct file_id lhs[static 1],
                       const struct file_id rhs[static 1],
                       struct picotm_error error[static 1]);

--- a/modules/libc/src/fildes/filetab.c
+++ b/modules/libc/src/fildes/filetab.c
@@ -216,11 +216,7 @@ struct file*
 fildes_filetab_ref_fildes(struct fildes_filetab self[static 1], int fildes,
                           bool new_file, struct picotm_error error[static 1])
 {
-    struct file_id id;
-    file_id_init_from_fildes(&id, fildes, error);
-    if (picotm_error_is_set(error))
-        return nullptr;
-
+    struct file_id id = FILE_ID_INITIALIZER(fildes);
     struct file* file;
 
     /* Try to find an existing file structure with the given id; iff

--- a/modules/libc/src/fildes/filetab.c
+++ b/modules/libc/src/fildes/filetab.c
@@ -164,14 +164,14 @@ find_by_id(struct fildes_filetab filetab[static 1],
 
         struct picotm_error cmp_error = PICOTM_ERROR_INITIALIZER;
 
-        int cmp = file_ref_if_id(file_beg, id, ne_fildes, &cmp_error);
+        bool found = file_ref_if_id(file_beg, id, ne_fildes, &cmp_error);
         if (picotm_error_is_set(&cmp_error)) {
             /* An error might be reported if the id's file descriptors don't
              * match. We save the error, but continue the loops. If we later
              * find a full match, the function succeeds. Otherwise, it reports
              * the last error. */
             memcpy(&saved_error, &cmp_error, sizeof(saved_error));
-        } else if (!cmp) {
+        } else if (found) {
             return file_beg;
         }
 
@@ -194,12 +194,10 @@ search_by_id(struct fildes_filetab filetab[static 1],
     const struct file* file_end = filetab_end(filetab);
 
     while (file_beg < file_end) {
-
-        int cmp = file_ref_or_set_up_if_id(file_beg, fildes, false, id,
-                                           error);
+        bool found = file_ref_or_set_up_if_id(file_beg, fildes, false, id, error);
         if (picotm_error_is_set(error))
             return nullptr;
-        else if (!cmp)
+        else if (found)
             return file_beg; /* set-up file structure; return */
 
         file_beg = filetab_next(filetab, file_beg);


### PR DESCRIPTION
Replace the ad-hoc file-id mechanism with a better one. The new implementation uses Linux system calls to compare files at the kernel level. Distinct files can now be detected correctly.