### PR TITLE
Compare files for non-equality

### DIFF
--- a/modules/libc/src/Makefile.am
+++ b/modules/libc/src/Makefile.am
@@ -34,8 +34,8 @@ libpicotm_c_la_SOURCES = allocator/allocator_event.c \
                          allocator/allocator_tx.h \
                          allocator/module.c \
                          allocator/module.h \
-                         compat/cmp_eq_files.c \
-                         compat/cmp_eq_files.h \
+                         compat/cmp_neq_files.c \
+                         compat/cmp_neq_files.h \
                          compat/get_current_dir_name.c \
                          compat/get_current_dir_name.h \
                          compat/malloc_usable_size.c \

--- a/modules/libc/src/compat/cmp_neq_files.c
+++ b/modules/libc/src/compat/cmp_neq_files.c
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-#include "cmp_eq_files.h"
+#include "cmp_neq_files.h"
 #include "picotm/picotm-error.h"
 #include <fcntl.h>
 #if defined(HAVE_SYS_SYSCALL_H) && HAVE_SYS_SYSCALL_H
@@ -70,10 +70,10 @@ static bool cmp_eq_files_dupfd(int lhs, int rhs, struct picotm_error *error)
 #endif
 
 bool
-cmp_eq_files(int lhs, int rhs, struct picotm_error* error)
+cmp_neq_files(int lhs, int rhs, struct picotm_error* error)
 {
 #if defined(SYS_kcmp)
-    bool eq = cmp_eq_files_kcmp(lhs, rhs, error);
+    bool neq = !cmp_eq_files_kcmp(lhs, rhs, error);
 #if defined(F_DUPFD_QUERY)
     if (picotm_error_is_set(error)) {
         switch(error->status) {
@@ -81,7 +81,7 @@ cmp_eq_files(int lhs, int rhs, struct picotm_error* error)
                 if (error->value.errno_hint == -ENOSYS) {
                     picotm_error_clear(error);
                     /* kcmp isn't available, but maybe F_DUPFD_QUERY is */
-                    return cmp_eq_files_dupfd(lhs, rhs, error);
+                    return !cmp_eq_files_dupfd(lhs, rhs, error);
                 }
                 [[fallthrough]];
             default:
@@ -89,9 +89,9 @@ cmp_eq_files(int lhs, int rhs, struct picotm_error* error)
         }
     }
 #endif
-    return eq;
+    return neq;
 #elif defined(F_DUPFD_QUERY)
-    return cmp_eq_files_dupfd(lhs, rhs, error);
+    return !cmp_eq_files_dupfd(lhs, rhs, error);
 #else
 #error file_id_cmp not implemented
 #endif

--- a/modules/libc/src/compat/cmp_neq_files.h
+++ b/modules/libc/src/compat/cmp_neq_files.h
@@ -24,7 +24,7 @@
 struct picotm_error;
 
 /**
- * \brief Tests two file descriptor's files for equality
+ * \brief Tests two file descriptor's files for non-equality.
  */
 bool
-cmp_eq_files(int lhs, int rhs, struct picotm_error* error);
+cmp_neq_files(int lhs, int rhs, struct picotm_error* error);

--- a/modules/libc/src/fildes/fileid.c
+++ b/modules/libc/src/fildes/fileid.c
@@ -18,7 +18,7 @@
  */
 
 #include "fileid.h"
-#include "compat/cmp_eq_files.h"
+#include "compat/cmp_neq_files.h"
 #include <assert.h>
 
 void
@@ -63,5 +63,5 @@ file_id_cmp_eq(const struct file_id* lhs, const struct file_id* rhs, struct pico
     }
 
     /* both file descriptors are distinct and valid */
-    return cmp_eq_files(lhs->fildes, rhs->fildes, error);
+    return !cmp_neq_files(lhs->fildes, rhs->fildes, error);
 }

--- a/modules/libc/src/fildes/fileid.h
+++ b/modules/libc/src/fildes/fileid.h
@@ -74,7 +74,7 @@ file_id_is_empty(const struct file_id* self);
  * \param   lhs The left-hand-side file id.
  * \param   rhs The right-hand-side file id.
  * \param[out]  error   Returns an error to the caller.
- * \returns True if the file ids are equal, or false otherwise.
+ * \returns False if the file ids are not equal, or true otherwise.
  *
  * Compares file ids. Also works for file ids that have been cleared, which
  * always compare as equal.


### PR DESCRIPTION
Add back the old method of comparing files via file buffer. This is not exact, but works as a fallback across all systems.